### PR TITLE
video js components

### DIFF
--- a/assets/js/romo-av/dropdown_video.js
+++ b/assets/js/romo-av/dropdown_video.js
@@ -1,0 +1,303 @@
+$.fn.romoDropdownVideo = function() {
+  return $.map(this, function(element) {
+    return new RomoDropdownVideo(element);
+  });
+}
+
+var RomoDropdownVideo = function(element) {
+  this.elem = $(element);
+
+  this.dropdown = this.elem.romoDropdown()[0];
+  this.doBindDropdown();
+
+  this.video = undefined;
+  this.doBindVideo();
+  this.elem.on('dropdown:loadBodySuccess', $.proxy(function(e, data, dropdown) {
+    this.doBindVideo();
+  }, this));
+
+  this.doInit();
+  this.elem.trigger('dropdownVideo:ready', [this]);
+}
+
+RomoDropdownVideo.prototype.doInit = function() {
+  // override as needed
+}
+
+RomoDropdownVideo.prototype.doBindDropdown = function() {
+  if (this.elem.data('romo-dropdown-clear-content') === undefined) {
+    this.elem.attr('data-romo-dropdown-clear-content', 'true');
+  }
+
+  // dropdown/video interactions
+
+  this.elem.on('dropdownVideo:video:loadedmetadata', $.proxy(function(e, videoObj, video, dropdownVideo) {
+    this.dropdown.doPlacePopupElem();
+  }, this));
+
+  this.elem.on('dropdownVideo:video:enterFullscreen', $.proxy(function(e, videoObj, video, dropdownVideo) {
+    // wait 1 sec then turn off dropdown body elem events - since we are in fullscreen
+    // mode, we don't care about them
+    setTimeout($.proxy(function() {
+      this.dropdown.doUnBindWindowBodyClick();
+      this.dropdown.doUnBindWindowBodyKeyUp();
+      this.dropdown.doUnBindElemKeyUp();
+    }, this), 1000);
+  }, this));
+  this.elem.on('dropdownVideo:video:exitFullscreen', $.proxy(function(e, videoObj, video, dropdownVideo) {
+    // wait 1 sec then turn on dropdown body elem events - since we are no longer
+    // in fullscreen mode, we need to care about them again
+    setTimeout($.proxy(function() {
+      this.dropdown.doBindWindowBodyClick();
+      this.dropdown.doBindWindowBodyKeyUp();
+      this.dropdown.doBindElemKeyUp();
+    }, this), 1000);
+  }, this));
+
+  // event proxies
+
+  this.elem.on('dropdown:ready', $.proxy(function(e, dropdown) {
+    this.elem.trigger('dropdownVideo:dropdown:ready', [dropdown, this]);
+  }, this));
+  this.elem.on('dropdown:toggle', $.proxy(function(e, dropdown) {
+    this.elem.trigger('dropdownVideo:dropdown:toggle', [dropdown, this]);
+  }, this));
+  this.elem.on('dropdown:popupOpen', $.proxy(function(e, dropdown) {
+    this.elem.trigger('dropdownVideo:dropdown:popupOpen', [dropdown, this]);
+  }, this));
+  this.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
+    this.elem.trigger('dropdownVideo:dropdown:popupClose', [dropdown, this]);
+  }, this));
+  this.elem.on('dropdown:loadBodyStart', $.proxy(function(e, dropdown) {
+    this.elem.trigger('dropdownVideo:dropdown:loadBodyStart', [dropdown, this]);
+  }, this));
+  this.elem.on('dropdown:loadBodySuccess', $.proxy(function(e, data, dropdown) {
+    this.elem.trigger('dropdownVideo:dropdown:loadBodySuccess', [data, dropdown, this]);
+  }, this));
+  this.elem.on('dropdown:loadBodyError', $.proxy(function(e, xhr, dropdown) {
+    this.elem.trigger('dropdownVideo:dropdown:loadBodyError', [xhr, dropdown, this]);
+  }, this));
+  this.elem.on('dropdown:dismiss', $.proxy(function(e, dropdown) {
+    this.elem.trigger('dropdownVideo:dropdown:dismiss', [dropdown, this]);
+  }, this));
+}
+
+RomoDropdownVideo.prototype.doBindVideo = function() {
+  var videoElem = this.dropdown.popupElem.find('[data-romo-video-auto="dropdownVideo"]');
+
+  this._bindVideoElemEvents(videoElem);
+  this._bindDropdownVideoTriggerEvents();
+
+  this.video = videoElem.romoVideo()[0];
+}
+
+// private
+
+RomoDropdownVideo.prototype._bindVideoElemEvents = function(videoElem) {
+  // playback events
+
+  videoElem.on('video:play', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:play', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:pause', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:pause', [videoObj, video, this]);
+  }, this));
+
+  // state events
+
+  videoElem.on('video:playing', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:playing', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:waiting', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:waiting', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:ended',  $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:ended', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:emptied', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:emptied', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:error', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:error', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:stalled', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:stalled', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:suspend', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:suspend', [videoObj, video, this]);
+  }, this));
+
+  // status events
+
+  videoElem.on('video:progress', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:progress', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:timeupdate', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:timeupdate', [videoObj, video, this]);
+  }, this));
+
+  // settings events
+
+  videoElem.on('video:volumechange', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:volumechange', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:durationchange', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:durationchange', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:ratechange', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:ratechange', [videoObj, video, this]);
+  }, this));
+
+  // fullscreen events
+
+  videoElem.on('video:enterFullscreen', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:enterFullscreen', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:exitFullscreen', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:exitFullscreen', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:fullscreenChange', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:fullscreenChange', [videoObj, video, this]);
+  }, this));
+
+  // load events
+
+  videoElem.on('video:loadstart', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:loadstart', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:loadedmetadata', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:loadedmetadata', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:loadeddata', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:loadeddata', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:canplay', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:canplay', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:canplaythrough', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('dropdownVideo:video:canplaythrough', [videoObj, video, this]);
+  }, this));
+}
+
+RomoDropdownVideo.prototype._bindDropdownVideoTriggerEvents = function() {
+  // playback triggers
+
+  this.elem.on('dropdownVideo:video:triggerPlay', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerPlay', []);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerPause', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerPause', []);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerTogglePlay', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerTogglePlay', []);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerSetPlaybackToTime', $.proxy(function(e, secondNum) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerSetPlaybackToTime', [secondNum]);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerSetPlaybackToFrame', $.proxy(function(e, frameNum) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerSetPlaybackToFrame', [frameNum]);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerSetPlaybackToPercent', $.proxy(function(e, percent) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerSetPlaybackToPercent', [percent]);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerModPlaybackByTime', $.proxy(function(e, secondsCount) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModPlaybackByTime', [secondsCount]);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerModPlaybackByFrames', $.proxy(function(e, frameCount) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModPlaybackByFrames', [frameCount]);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerModPlaybackByPercent', $.proxy(function(e, percent) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModPlaybackByPercent', [percent]);
+    }
+  }, this));
+
+  // settings triggers
+
+  this.elem.on('dropdownVideo:video:triggerMute', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerMute', []);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerUnmute', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerUnmute', []);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerToggleMute', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerToggleMute', []);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerSetVolumeToPercent', $.proxy(function(e, percent) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerSetVolumeToPercent', [percent]);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerModVolumeByPercent', $.proxy(function(e, percent) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModVolumeByPercent', [percent]);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerSetPlaybackRate', $.proxy(function(e, rate) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerSetPlaybackRate', [rate]);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerModPlaybackRate', $.proxy(function(e, rate) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModPlaybackRate', [rate]);
+    }
+  }, this));
+
+  // fullscreen triggers
+
+  this.elem.on('dropdownVideo:video:triggerEnterFullscreen', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerEnterFullscreen', []);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerExitFullscreen', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerExitFullscreen', []);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerToggleFullscreen', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerToggleFullscreen', []);
+    }
+  }, this));
+
+  // load triggers
+
+  this.elem.on('dropdownVideo:video:triggerLoad', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerLoad', []);
+    }
+  }, this));
+  this.elem.on('dropdownVideo:video:triggerModSource', $.proxy(function(e, source) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModSource', [source]);
+    }
+  }, this));
+}
+
+Romo.onInitUI(function(e) {
+  Romo.initUIElems(e, '[data-romo-dropdownVideo-auto="true"]').romoDropdownVideo();
+});

--- a/assets/js/romo-av/modal_video.js
+++ b/assets/js/romo-av/modal_video.js
@@ -1,0 +1,312 @@
+$.fn.romoModalVideo = function() {
+  return $.map(this, function(element) {
+    return new RomoModalVideo(element);
+  });
+}
+
+var RomoModalVideo = function(element) {
+  this.elem = $(element);
+
+  this.modal = this.elem.romoModal()[0];
+  this.doBindModal();
+
+  this.video = undefined;
+  this.doBindVideo();
+  this.elem.on('modal:loadBodySuccess', $.proxy(function(e, data, modal) {
+    this.doBindVideo();
+  }, this));
+
+  this.doInit();
+  this.elem.trigger('modalVideo:ready', [this]);
+}
+
+RomoModalVideo.prototype.doInit = function() {
+  // override as needed
+}
+
+RomoModalVideo.prototype.doBindModal = function() {
+  if (this.elem.data('romo-modal-clear-content') === undefined) {
+    this.elem.attr('data-romo-modal-clear-content', 'true');
+  }
+
+  // modal/video interactions
+
+  this.elem.on('modalVideo:video:loadedmetadata', $.proxy(function(e, videoObj, video, modalVideo) {
+    this.modal.doPlacePopupElem();
+  }, this));
+
+  this.elem.on('modalVideo:video:enterFullscreen', $.proxy(function(e, videoObj, video, modalVideo) {
+    // wait 1 sec then turn off modal body elem events - since we are in fullscreen
+    // mode, we don't care about them
+    setTimeout($.proxy(function() {
+      this.modal.doUnBindWindowBodyClick();
+      this.modal.doUnBindWindowBodyKeyUp();
+      this.modal.doUnBindElemKeyUp();
+    }, this), 1000);
+  }, this));
+  this.elem.on('modalVideo:video:exitFullscreen', $.proxy(function(e, videoObj, video, modalVideo) {
+    // wait 1 sec then turn on modal body elem events - since we are no longer
+    // in fullscreen mode, we need to care about them again
+    setTimeout($.proxy(function() {
+      this.modal.doBindWindowBodyClick();
+      this.modal.doBindWindowBodyKeyUp();
+      this.modal.doBindElemKeyUp();
+    }, this), 1000);
+  }, this));
+
+  // event proxies
+
+  this.elem.on('modal:ready', $.proxy(function(e, modal) {
+    this.elem.trigger('modalVideo:modal:ready', [modal, this]);
+  }, this));
+  this.elem.on('modal:toggle', $.proxy(function(e, modal) {
+    this.elem.trigger('modalVideo:modal:toggle', [modal, this]);
+  }, this));
+  this.elem.on('modal:popupOpen', $.proxy(function(e, modal) {
+    this.elem.trigger('modalVideo:modal:popupOpen', [modal, this]);
+  }, this));
+  this.elem.on('modal:popupClose', $.proxy(function(e, modal) {
+    this.elem.trigger('modalVideo:modal:popupClose', [modal, this]);
+  }, this));
+  this.elem.on('modal:dragStart', $.proxy(function(e, modal) {
+    this.elem.trigger('modalVideo:modal:dragStart', [modal, this]);
+  }, this));
+  this.elem.on('modal:dragMove', $.proxy(function(e, placeX, placeY, modal) {
+    this.elem.trigger('modalVideo:modal:dragMove', [placeX, placeY, modal, this]);
+  }, this));
+  this.elem.on('modal:dragStop', $.proxy(function(e, modal) {
+    this.elem.trigger('modalVideo:modal:dragStop', [modal, this]);
+  }, this));
+  this.elem.on('modal:loadBodyStart', $.proxy(function(e, modal) {
+    this.elem.trigger('modalVideo:modal:loadBodyStart', [modal, this]);
+  }, this));
+  this.elem.on('modal:loadBodySuccess', $.proxy(function(e, data, modal) {
+    this.elem.trigger('modalVideo:modal:loadBodySuccess', [data, modal, this]);
+  }, this));
+  this.elem.on('modal:loadBodyError', $.proxy(function(e, xhr, modal) {
+    this.elem.trigger('modalVideo:modal:loadBodyError', [xhr, modal, this]);
+  }, this));
+  this.elem.on('modal:dismiss', $.proxy(function(e, modal) {
+    this.elem.trigger('modalVideo:modal:dismiss', [modal, this]);
+  }, this));
+}
+
+RomoModalVideo.prototype.doBindVideo = function() {
+  var videoElem = this.modal.popupElem.find('[data-romo-video-auto="modalVideo"]');
+
+  this._bindVideoElemEvents(videoElem);
+  this._bindModalVideoTriggerEvents();
+
+  this.video = videoElem.romoVideo()[0];
+}
+
+// private
+
+RomoModalVideo.prototype._bindVideoElemEvents = function(videoElem) {
+  // playback events
+
+  videoElem.on('video:play', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:play', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:pause', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:pause', [videoObj, video, this]);
+  }, this));
+
+  // state events
+
+  videoElem.on('video:playing', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:playing', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:waiting', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:waiting', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:ended',  $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:ended', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:emptied', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:emptied', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:error', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:error', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:stalled', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:stalled', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:suspend', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:suspend', [videoObj, video, this]);
+  }, this));
+
+  // status events
+
+  videoElem.on('video:progress', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:progress', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:timeupdate', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:timeupdate', [videoObj, video, this]);
+  }, this));
+
+  // settings events
+
+  videoElem.on('video:volumechange', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:volumechange', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:durationchange', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:durationchange', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:ratechange', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:ratechange', [videoObj, video, this]);
+  }, this));
+
+  // fullscreen events
+
+  videoElem.on('video:enterFullscreen', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:enterFullscreen', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:exitFullscreen', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:exitFullscreen', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:fullscreenChange', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:fullscreenChange', [videoObj, video, this]);
+  }, this));
+
+  // load events
+
+  videoElem.on('video:loadstart', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:loadstart', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:loadedmetadata', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:loadedmetadata', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:loadeddata', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:loadeddata', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:canplay', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:canplay', [videoObj, video, this]);
+  }, this));
+  videoElem.on('video:canplaythrough', $.proxy(function(e, videoObj, video) {
+    this.elem.trigger('modalVideo:video:canplaythrough', [videoObj, video, this]);
+  }, this));
+}
+
+RomoModalVideo.prototype._bindModalVideoTriggerEvents = function() {
+  // playback triggers
+
+  this.elem.on('modalVideo:video:triggerPlay', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerPlay', []);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerPause', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerPause', []);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerTogglePlay', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerTogglePlay', []);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerSetPlaybackToTime', $.proxy(function(e, secondNum) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerSetPlaybackToTime', [secondNum]);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerSetPlaybackToFrame', $.proxy(function(e, frameNum) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerSetPlaybackToFrame', [frameNum]);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerSetPlaybackToPercent', $.proxy(function(e, percent) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerSetPlaybackToPercent', [percent]);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerModPlaybackByTime', $.proxy(function(e, secondsCount) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModPlaybackByTime', [secondsCount]);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerModPlaybackByFrames', $.proxy(function(e, frameCount) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModPlaybackByFrames', [frameCount]);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerModPlaybackByPercent', $.proxy(function(e, percent) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModPlaybackByPercent', [percent]);
+    }
+  }, this));
+
+  // settings triggers
+
+  this.elem.on('modalVideo:video:triggerMute', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerMute', []);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerUnmute', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerUnmute', []);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerToggleMute', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerToggleMute', []);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerSetVolumeToPercent', $.proxy(function(e, percent) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerSetVolumeToPercent', [percent]);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerModVolumeByPercent', $.proxy(function(e, percent) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModVolumeByPercent', [percent]);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerSetPlaybackRate', $.proxy(function(e, rate) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerSetPlaybackRate', [rate]);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerModPlaybackRate', $.proxy(function(e, rate) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModPlaybackRate', [rate]);
+    }
+  }, this));
+
+  // fullscreen triggers
+
+  this.elem.on('modalVideo:video:triggerEnterFullscreen', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerEnterFullscreen', []);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerExitFullscreen', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerExitFullscreen', []);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerToggleFullscreen', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerToggleFullscreen', []);
+    }
+  }, this));
+
+  // load triggers
+
+  this.elem.on('modalVideo:video:triggerLoad', $.proxy(function(e) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerLoad', []);
+    }
+  }, this));
+  this.elem.on('modalVideo:video:triggerModSource', $.proxy(function(e, source) {
+    if (this.video != undefined) {
+      this.video.elem.trigger('video:triggerModSource', [source]);
+    }
+  }, this));
+}
+
+Romo.onInitUI(function(e) {
+  Romo.initUIElems(e, '[data-romo-modalVideo-auto="true"]').romoModalVideo();
+});

--- a/assets/js/romo-av/video.js
+++ b/assets/js/romo-av/video.js
@@ -1,0 +1,441 @@
+$.fn.romoVideo = function() {
+  return $.map(this, function(element) {
+    return new RomoVideo(element);
+  });
+}
+
+var RomoVideo = function(element) {
+  this.elem     = $(element);
+  this.videoObj = this.elem[0];
+
+  this._bindFullscreen();
+  this._bindVideo();
+
+  this.doInit();
+  this._loadState();
+
+  this.elem.trigger('video:ready', [this.video, this]);
+}
+
+RomoVideo.prototype.doInit = function() {
+  // override as needed
+}
+
+// Playback methods
+
+RomoVideo.prototype.doPlay = function() {
+  this.videoObj.play();
+}
+
+RomoVideo.prototype.doPause = function() {
+  this.videoObj.pause();
+}
+
+RomoVideo.prototype.doTogglePlay = function() {
+  if (this.videoObj.paused) {
+    this.videoObj.play();
+  } else {
+    this.videoObj.pause();
+  }
+}
+
+RomoVideo.prototype.doSetPlaybackToTime = function(secondNum) {
+  this._setPlayback(secondNum);
+}
+
+RomoVideo.prototype.doSetPlaybackToFrame = function(frameNum) {
+  if(this.fpsEnabled !== true){ return; }
+  this._setPlayback(this._frameNumToSecondNum(frameNum));
+}
+
+RomoVideo.prototype.doSetPlaybackToPercent = function(percent) {
+  if(!this.videoObj.duration){ return; }
+  this._setPlayback(this._percentToSecondNum(percent));
+}
+
+RomoVideo.prototype.doModPlaybackByTime = function(secondsCount) {
+  this._setPlayback(this.videoObj.currentTime + secondsCount);
+}
+
+RomoVideo.prototype.doModPlaybackByFrames = function(frameCount) {
+  if(this.fpsEnabled !== true){ return; }
+  this._setPlayback(this.videoObj.currentTime + this._frameNumToSecondNum(frameCount));
+}
+
+RomoVideo.prototype.doModPlaybackByPercent = function(percent) {
+  if(!this.videoObj.duration){ return; }
+  this._setPlayback(this.videoObj.currentTime + this._percentToSecondNum(percent));
+}
+
+// Settings methods
+
+RomoVideo.prototype.doMute = function() {
+  this.videoObj.muted = true;
+}
+
+RomoVideo.prototype.doUnmute = function() {
+  this.videoObj.muted = false;
+}
+
+RomoVideo.prototype.doToggleMute = function() {
+  this.videoObj.muted = !this.videoObj.muted;
+}
+
+RomoVideo.prototype.doSetVolumnToPercent = function(percent) {
+  this._setVolume(volume);
+}
+
+RomoVideo.prototype.doModVolumeByPercent = function(percent) {
+  this._setVolume(this.videoObj.volume + percent);
+}
+
+RomoVideo.prototype.doSetPlaybackToRate = function(rate) {
+  this.videoObj.playbackRate = rate;
+}
+
+RomoVideo.prototype.doModPlaybackByRate = function(rate) {
+  this.videoObj.playbackRate = this.videoObj.playbackRate + rate;
+}
+
+// Fullscreen methods
+
+RomoVideo.prototype.doEnterFullscreen = function() {
+  this._requestFullscreen();
+}
+
+RomoVideo.prototype.doExitFullscreen = function() {
+  this._exitFullscreen();
+}
+
+RomoVideo.prototype.doToggleFullscreen = function() {
+  if (this.fullScreen === true) {
+    this._exitFullscreen();
+  } else {
+    this._requestFullscreen();
+  }
+}
+
+// Load methods
+
+RomoVideo.prototype.doLoad = function() {
+  this.doPause();
+  this._loadState();
+  this.videoObj.load();
+}
+
+RomoVideo.prototype.doModSource = function(source) {
+  this.videoObj.src = source;
+}
+
+// private
+
+RomoVideo.prototype._setPlayback = function(newSecondNum) {
+  if (newSecondNum > this.videoObj.duration) {
+    if (this.elem.prop('loop') === true){
+      this.videoObj.currentTime = (newSecondNum - this.videoObj.duration);
+    } else {
+      this.videoObj.currentTime = this.videoObj.duration;
+    }
+  } else if (newSecondNum < 0) {
+    if (this.elem.prop('loop') === true){
+      this.videoObj.currentTime = (this.videoObj.duration - (0 - newSecondNum));
+    } else {
+      this.videoObj.currentTime = 0;
+    }
+  } else {
+    this.videoObj.currentTime = newSecondNum;
+  }
+}
+
+RomoVideo.prototype._frameNumToSecondNum = function(frameNum) {
+  return frameNum / this.fps;
+}
+
+RomoVideo.prototype._percentToSecondNum = function(percent) {
+  return percent * this.videoObj.duration;
+}
+
+RomoVideo.prototype._setVolume = function(percent) {
+  if (percent > 1) {
+    this.videoObj.volume = 1;
+  } else if (percent < 0) {
+    this.videoObj.volume = 0;
+  } else {
+    this.videoObj.volume = percent;
+  }
+}
+
+RomoVideo.prototype._loadState = function() {
+  this.fps = this.elem.data('romo-video-fps');
+  if (this.fps && this.fps > 0) {
+    this.fpsEnabled = true;
+  } else {
+    this.fpsEnabled = false;
+  }
+}
+
+RomoVideo.prototype._bindFullscreen = function() {
+  var fullscreenElem = this.elem.closest(this.elem.data('romo-video-fullscreen-elem'));
+  if (fullscreenElem[0] !== undefined) {
+    this.fullscreenElem = fullscreenElem;
+  } else {
+    this.fullscreenElem = this.elem;
+  }
+
+  this._browserRequestFullscreen = this._getBrowserRequestFullscreen(this.fullscreenElem);
+  this._browserExitFullscreen    = this._getBrowserExitFullscreen();
+
+  $(document).on('fullscreenchange',       $.proxy(this._onDocumentFullscreenChange, this));
+  $(document).on('mozfullscreenchange',    $.proxy(this._onDocumentFullscreenChange, this));
+  $(document).on('msfullscreenchange',     $.proxy(this._onDocumentFullscreenChange, this));
+  $(document).on('webkitfullscreenchange', $.proxy(this._onDocumentFullscreenChange, this));
+}
+
+RomoVideo.prototype._bindVideo = function() {
+  this._bindVideoElemEvents();
+  this._bindVideoTriggerEvents();
+}
+
+RomoVideo.prototype._bindVideoElemEvents = function() {
+  // playback events
+
+  this.elem.on('play', $.proxy(function(e) {
+    this.elem.trigger('video:play', [this.videoObj, this]);
+  }, this));
+  this.elem.on('pause', $.proxy(function(e) {
+    this.elem.trigger('video:pause', [this.videoObj, this]);
+  }, this));
+
+  // state events
+
+  this.elem.on('playing', $.proxy(function(e) {
+    this.elem.trigger('video:playing', [this.videoObj, this]);
+  }, this));
+  this.elem.on('waiting', $.proxy(function(e) {
+    this.elem.trigger('video:waiting', [this.videoObj, this]);
+  }, this));
+  this.elem.on('ended',  $.proxy(function(e) {
+    this.elem.trigger('video:ended', [this.videoObj, this]);
+  }, this));
+  this.elem.on('emptied', $.proxy(function(e) {
+    this.elem.trigger('video:emptied', [this.videoObj, this]);
+  }, this));
+  this.elem.on('error', $.proxy(function(e) {
+    this.elem.trigger('video:error', [this.videoObj, this]);
+  }, this));
+  this.elem.on('stalled', $.proxy(function(e) {
+    this.elem.trigger('video:stalled', [this.videoObj, this]);
+  }, this));
+  this.elem.on('suspend', $.proxy(function(e) {
+    this.elem.trigger('video:suspend', [this.videoObj, this]);
+  }, this));
+
+  // status events
+
+  this.elem.on('progress', $.proxy(function(e) {
+    this.elem.trigger('video:progress', [this.videoObj, this]);
+  }, this));
+  this.elem.on('timeupdate', $.proxy(function(e) {
+    this.elem.trigger('video:timeupdate', [this.videoObj, this]);
+  }, this));
+
+  // settings events
+
+  this.elem.on('volumechange', $.proxy(function(e) {
+    this.elem.trigger('video:volumechange', [this.videoObj, this]);
+  }, this));
+  this.elem.on('durationchange', $.proxy(function(e) {
+    this.elem.trigger('video:durationchange', [this.videoObj, this]);
+  }, this));
+  this.elem.on('ratechange', $.proxy(function(e) {
+    this.elem.trigger('video:ratechange', [this.videoObj, this]);
+  }, this));
+
+  // load events
+
+  this.elem.on('loadstart', $.proxy(function(e) {
+    this.elem.trigger('video:loadstart', [this.videoObj, this]);
+  }, this));
+  this.elem.on('loadedmetadata', $.proxy(function(e) {
+    this.elem.trigger('video:loadedmetadata', [this.videoObj, this]);
+  }, this));
+  this.elem.on('loadeddata', $.proxy(function(e) {
+    this.elem.trigger('video:loadeddata', [this.videoObj, this]);
+  }, this));
+  this.elem.on('canplay', $.proxy(function(e) {
+    this.elem.trigger('video:canplay', [this.videoObj, this]);
+  }, this));
+  this.elem.on('canplaythrough', $.proxy(function(e) {
+    this.elem.trigger('video:canplaythrough', [this.videoObj, this]);
+  }, this));
+}
+
+RomoVideo.prototype._bindVideoTriggerEvents = function() {
+  // playback triggers
+
+  this.elem.on('video:triggerPlay', $.proxy(function(e) {
+    this.doPlay(); return false;
+  }, this));
+  this.elem.on('video:triggerPause', $.proxy(function(e) {
+    this.doPause(); return false;
+  }, this));
+  this.elem.on('video:triggerTogglePlay', $.proxy(function(e) {
+    this.doTogglePlay(); return false;
+  }, this));
+  this.elem.on('video:triggerSetPlaybackToTime', $.proxy(function(e, secondNum) {
+    this.doSetPlaybackToTime(secondNum); return false;
+  }, this));
+  this.elem.on('video:triggerSetPlaybackToFrame', $.proxy(function(e, frameNum) {
+    this.doSetPlaybackToFrame(frameNum); return false;
+  }, this));
+  this.elem.on('video:triggerSetPlaybackToPercent', $.proxy(function(e, percent) {
+    this.doSetPlaybackToPercent(percent); return false;
+  }, this));
+  this.elem.on('video:triggerModPlaybackByTime', $.proxy(function(e, secondsCount) {
+    this.doModPlaybackByTime(secondsCount); return false;
+  }, this));
+  this.elem.on('video:triggerModPlaybackByFrames', $.proxy(function(e, frameCount) {
+    this.doModPlaybackByFrames(frameCount); return false;
+  }, this));
+  this.elem.on('video:triggerModPlaybackByPercent', $.proxy(function(e, percent) {
+    this.doModPlaybackByPercent(percent); return false;
+  }, this));
+
+  // settings triggers
+
+  this.elem.on('video:triggerMute', $.proxy(function(e) {
+    this.doMute(); return false;
+  }, this));
+  this.elem.on('video:triggerUnmute', $.proxy(function(e) {
+    this.doUnMute(); return false;
+  }, this));
+  this.elem.on('video:triggerToggleMute', $.proxy(function(e) {
+    this.doToggleMute(); return false;
+  }, this));
+  this.elem.on('video:triggerSetVolumeToPercent', $.proxy(function(e, percent) {
+    this.doSetVolumnToPercent(percent); return false;
+  }, this));
+  this.elem.on('video:triggerModVolumeByPercent', $.proxy(function(e, percent) {
+    this.doModVolumeByPercent(percent); return false;
+  }, this));
+  this.elem.on('video:triggerSetPlaybackRate', $.proxy(function(e, rate) {
+    this.doSetPlaybackToRate(rate); return false;
+  }, this));
+  this.elem.on('video:triggerModPlaybackRate', $.proxy(function(e, rate) {
+    this.doModPlaybackByRate(rate); return false;
+  }, this));
+
+  // fullscreen triggers
+
+  this.elem.on('video:triggerEnterFullscreen', $.proxy(function(e) {
+    this.doEnterFullscreen(); return false;
+  }, this));
+  this.elem.on('video:triggerExitFullscreen', $.proxy(function(e) {
+    this.doExitFullscreen(); return false;
+  }, this));
+  this.elem.on('video:triggerToggleFullscreen', $.proxy(function(e) {
+    this.doToggleFullscreen(); return false;
+  }, this));
+
+  // load triggers
+
+  this.elem.on('video:triggerLoad', $.proxy(function(e) {
+    this.doLoad(); return false;
+  }, this));
+  this.elem.on('video:triggerModSource', $.proxy(function(e, source) {
+    this.doModSource(source); return false;
+  }, this));
+
+}
+
+RomoVideo.prototype._onDocumentFullscreenChange = function(e) {
+  if (this._getCurrentFullscreenElem() === this.fullscreenElem[0]) {
+    this.fullScreen = true;
+    this.elem.trigger('video:enterFullscreen', [this.videoObj, this]);
+    this.elem.trigger('video:fullscreenChange', [this.videoObj, this]);
+  } else if (this.fullScreen === true) {
+    this.fullScreen = false;
+    this.elem.trigger('video:exitFullscreen', [this.videoObj, this]);
+    this.elem.trigger('video:fullscreenChange', [this.videoObj, this]);
+  }
+}
+
+RomoVideo.prototype._getCurrentFullscreenElem = function() {
+  return document.fullscreenElement        ||
+         document.mozFullScreenElement     ||
+         document.msFullscreenElement      ||
+         document.webkitFullscreenElement;
+}
+
+RomoVideo.prototype._requestFullscreen = function() {
+  if (this._canFullscreen()) {
+    this._browserRequestFullscreen.apply(this.fullscreenElem[0]);
+  } else {
+    return false;
+  }
+}
+
+RomoVideo.prototype._exitFullscreen = function() {
+  if (this._canFullscreen()) {
+    this._browserExitFullscreen.apply(document);
+  } else {
+    return false;
+  }
+}
+
+RomoVideo.prototype._canFullscreen = function() {
+  if (this._browserRequestFullscreen === undefined || this._browserExitFullscreen === undefined) {
+    return false;
+  }
+
+  if (document.fullscreenEnabled !== undefined) {
+    return document.fullscreenEnabled;
+  } else if (document.mozFullScreenEnabled !== undefined) {
+    return document.mozFullScreenEnabled;
+  } else if (document.msFullscreenEnabled !== undefined) {
+    return document.msFullscreenEnabled;
+  } else if (document.webkitFullscreenEnabled !== undefined) {
+    return document.webkitFullscreenEnabled;
+  } else {
+    return false;
+  }
+}
+
+RomoVideo.prototype._getBrowserRequestFullscreen = function(fullscreenElem) {
+  // look for the browser-specific requestFullscreen function and return it
+
+  if (fullscreenElem[0].requestFullscreen) {
+    return fullscreenElem[0].requestFullscreen;
+  } else if (fullscreenElem[0].mozRequestFullScreen) {
+    return fullscreenElem[0].mozRequestFullScreen;
+  } else if (fullscreenElem[0].msRequestFullscreen) {
+    return fullscreenElem[0].msRequestFullscreen;
+  } else if (fullscreenElem[0].webkitRequestFullscreen) {
+    return this.fullscreenElem[0].webkitRequestFullscreen;
+  } else {
+    return undefined;
+  }
+}
+
+RomoVideo.prototype._getBrowserExitFullscreen = function(fullscreenElem) {
+  // look for the browser-specific exitFullscreen function and return it
+  // we use the document because any non-video fullscreen containers will not
+  // have this function, calling the document function will exit anything that
+  // has been fullscreened
+
+  if (document.exitFullscreen) {
+    return document.exitFullscreen;
+  } else if (document.mozCancelFullScreen) {
+    return document.mozCancelFullScreen;
+  } else if (document.msExitFullscreen) {
+    return document.msExitFullscreen;
+  } else if (document.webkitExitFullscreen) {
+    return document.webkitExitFullscreen;
+  } else {
+    return undefined;
+  }
+}
+
+Romo.onInitUI(function(e) {
+  Romo.initUIElems(e, '[data-romo-video-auto="true"]').romoVideo();
+});


### PR DESCRIPTION
This adds js assets for video, model video and dropdown video
components.  These bind video elems and add romo-style init and
events plus add a friendly/rich API.

The modal/dropdown components act like the modal/dropdown form
components, composing videos in modals/dropdowns and handling all
interactiions and event/api proxying.

Note: this doesn't add and css or styling - just the video api.  All
styling is left open to the developer.

This is the "v" portion in "romo-av".  Audio will be added some time
in the future.

@jcredding ready for review.
