### PR TITLE
video js: add get formatted time helper method

### DIFF
--- a/assets/js/romo-av/video.js
+++ b/assets/js/romo-av/video.js
@@ -166,6 +166,20 @@ RomoVideo.prototype.getTotalBufferedTuples = function() {
   return tuples;
 }
 
+// Load methods
+
+RomoVideo.prototype.doLoad = function() {
+  this.doPause();
+  this._loadState();
+  this.videoObj.load();
+}
+
+RomoVideo.prototype.doModSource = function(source) {
+  this.videoObj.src = source;
+}
+
+// Helper methods
+
 RomoVideo.prototype.getVideoTimeInFrames = function(time) {
   if (this.fpsEnabled !== true) {
     return 0;
@@ -215,16 +229,22 @@ RomoVideo.prototype.getVideoPercentInFrames = function(percent) {
   }
 }
 
-// Load methods
+RomoVideo.prototype.getVideoFormattedTime = function(seconds) {
+  if (isNaN(parseInt(seconds)) === true){ return '00:00.000'; }
+  else if (seconds === 0){ return '00:00.000'; }
 
-RomoVideo.prototype.doLoad = function() {
-  this.doPause();
-  this._loadState();
-  this.videoObj.load();
-}
+  var abs  = Math.abs(seconds);
+  var hrs  = Math.floor(abs / 3600);
+  var mins = Math.floor((abs - (hrs * 3600)) / 60);
+  var secs = Math.floor(abs % 60);
+  var ms   = (abs - Math.floor(abs));
 
-RomoVideo.prototype.doModSource = function(source) {
-  this.videoObj.src = source;
+  var t = (hrs ? hrs + ':' : '') +
+          (mins < 10 ? '0' : '') + mins + ':' +
+          (secs < 10 ? '0' : '') + secs + ms.toFixed(3).slice(1);
+
+  if (seconds > 0){ return t; }
+  else{ return '-'+t; }
 }
 
 // private


### PR DESCRIPTION
This adds a method that, given a number of seconds, will return
that number formatted in hours/mins/secs/ms: `hh:mm:ss.mmm`. It
handles both negative and positive numbers and also `NaN` inputs.

Note: this also formally reorgs the other "helper" methods as such.

![image-wsz0e](https://cloud.githubusercontent.com/assets/82110/10288868/14e2ceea-6b61-11e5-8741-696fbc61bfc7.jpg)

@jcredding ready for review.
