### PR TITLE
video js: add methods for controlling the video loop property

### DIFF
--- a/assets/js/romo-av/video.js
+++ b/assets/js/romo-av/video.js
@@ -86,6 +86,30 @@ RomoVideo.prototype.doToggleMute = function() {
   this.videoObj.muted = !this.videoObj.muted;
 }
 
+RomoVideo.prototype.getLoop = function() {
+  return this.elem.prop('loop');
+}
+
+RomoVideo.prototype.doLoop = function() {
+  this.elem.prop('loop', true);
+  this.elem.trigger('video:loop',       [this.videoObj, this]);
+  this.elem.trigger('video:loopChange', [true, this.videoObj, this]);
+}
+
+RomoVideo.prototype.doNoLoop = function() {
+  this.elem.prop('loop', false);
+  this.elem.trigger('video:noloop',     [this.videoObj, this]);
+  this.elem.trigger('video:loopChange', [false, this.videoObj, this]);
+}
+
+RomoVideo.prototype.doToggleLoop = function() {
+  if (this.getLoop() !== true) {
+    this.doLoop();
+  } else {
+    this.doNoLoop();
+  }
+}
+
 RomoVideo.prototype.doSetVolumnToPercent = function(percent) {
   this._setVolume(volume);
 }


### PR DESCRIPTION
I add a `getLoop` method to abstract the property lookup logic since
the native video object doesn't know anything about loop settings.
The other methods are similar to the mute setting methods.  Note:
I manually publish loop setting events as the native video object
doesn't do it for me like it does for the mute settings.

@jcredding ready for review.
