### PR TITLE
video js: volume handling related cleanups

### DIFF
--- a/assets/js/romo-av/video.js
+++ b/assets/js/romo-av/video.js
@@ -76,14 +76,17 @@ RomoVideo.prototype.doModPlaybackByPercent = function(percent) {
 
 RomoVideo.prototype.doMute = function() {
   this.videoObj.muted = true;
+  this.elem.trigger('video:volumechange', [this.videoObj, this]);
 }
 
 RomoVideo.prototype.doUnmute = function() {
   this.videoObj.muted = false;
+  this.elem.trigger('video:volumechange', [this.videoObj, this]);
 }
 
 RomoVideo.prototype.doToggleMute = function() {
   this.videoObj.muted = !this.videoObj.muted;
+  this.elem.trigger('video:volumechange', [this.videoObj, this]);
 }
 
 RomoVideo.prototype.getLoop = function() {
@@ -110,12 +113,12 @@ RomoVideo.prototype.doToggleLoop = function() {
   }
 }
 
-RomoVideo.prototype.doSetVolumnToPercent = function(percent) {
-  this._setVolume(volume);
+RomoVideo.prototype.doSetVolumeToPercent = function(percent) {
+  this._setVolume(percent / 100);
 }
 
 RomoVideo.prototype.doModVolumeByPercent = function(percent) {
-  this._setVolume(this.videoObj.volume + percent);
+  this._setVolume(this.videoObj.volume + (percent / 100));
 }
 
 RomoVideo.prototype.doSetPlaybackToRate = function(rate) {
@@ -203,6 +206,22 @@ RomoVideo.prototype.getTotalBufferedTuples = function() {
     tuples.push([buffered.start(i), buffered.end(i)]);
   }
   return tuples;
+}
+
+RomoVideo.prototype.getVolumeValue = function() {
+  if (this.videoObj.muted === true) {
+    return 0;
+  } else {
+    return this.videoObj.volume;
+  }
+}
+
+RomoVideo.prototype.getVolumePercent = function() {
+  return this.getVolumeValue() * 100;
+}
+
+RomoVideo.prototype.getVolumeMuted = function() {
+  return this.videoObj.muted === true || this.getVolumePercent() === 0;
 }
 
 // Load methods
@@ -302,17 +321,18 @@ RomoVideo.prototype._frameNumToSecondNum = function(frameNum) {
 }
 
 RomoVideo.prototype._percentToSecondNum = function(percent) {
-  return percent * this.getDurationTime();
+  return (percent / 100) * this.getDurationTime();
 }
 
-RomoVideo.prototype._setVolume = function(percent) {
-  if (percent > 1) {
+RomoVideo.prototype._setVolume = function(value) {
+  if (value > 1) {
     this.videoObj.volume = 1;
-  } else if (percent < 0) {
+  } else if (value < 0) {
     this.videoObj.volume = 0;
   } else {
-    this.videoObj.volume = percent;
+    this.videoObj.volume = value;
   }
+  this.doUnmute();
 }
 
 RomoVideo.prototype._loadState = function() {
@@ -457,13 +477,13 @@ RomoVideo.prototype._bindVideoTriggerEvents = function() {
     this.doMute(); return false;
   }, this));
   this.elem.on('video:triggerUnmute', $.proxy(function(e) {
-    this.doUnMute(); return false;
+    this.doUnmute(); return false;
   }, this));
   this.elem.on('video:triggerToggleMute', $.proxy(function(e) {
     this.doToggleMute(); return false;
   }, this));
   this.elem.on('video:triggerSetVolumeToPercent', $.proxy(function(e, percent) {
-    this.doSetVolumnToPercent(percent); return false;
+    this.doSetVolumeToPercent(percent); return false;
   }, this));
   this.elem.on('video:triggerModVolumeByPercent', $.proxy(function(e, percent) {
     this.doModVolumeByPercent(percent); return false;


### PR DESCRIPTION
This updates some logic related to handling volume, including:
- triggering the volume change event on mute changes (I originally
  assumed this was being fired as muting is a volume change; I was
  wrong).
- add API methods to get volume value/percent.  This also interprets
  muted as "volume zero" and "volume zero" as muted.  The effect here
  is that you can mute and the volume looks like it goes down to
  zero and when you unmute, the volume is reset to what it previously
  was.  This is handy when driving UI (vol slider and/or mute state
  icon) via these values.
- fix a few typos

Note: this also updates all percent related API methods to expect
given percent values to be between 0 and 100 and return percents as
values between 0 and 100.  There was mixed usage/handling previously
so this just cleans things up to be consistent.

@jcredding ready for review.
