### PR TITLE
update Dassets to only config once and be able to reset it

### DIFF
--- a/lib/romo-av/dassets.rb
+++ b/lib/romo-av/dassets.rb
@@ -9,6 +9,8 @@ module Romo::Av::Dassets
   # loading this combination.
 
   def self.configure!
+    return if @configured
+
     Dassets.configure do |c|
       c.source Romo::Av.gem_assets_path do |s|
         s.filter{ |paths| paths.reject{ |p| File.basename(p) =~ /^_/ } }
@@ -31,8 +33,11 @@ module Romo::Av::Dassets
         'js/romo-av-audio.js',
         'js/romo-av-video.js'
       ]
-
     end
+
+    @configured = true
   end
+
+  def self.reset!; @configured = false; end
 
 end

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -7,7 +7,15 @@ module Romo::Av::Dassets
 
   class UnitTests < Assert::Context
     desc "Romo::Av::Dassets"
+    setup do
+      Romo::Av::Dassets.reset!
+    end
+    teardown do
+      Romo::Av::Dassets.reset!
+    end
     subject{ Romo::Av::Dassets }
+
+    should have_imeths :configure!, :reset!
 
     should "configure Romo::Av with Dassets" do
       subject.configure!
@@ -34,6 +42,23 @@ module Romo::Av::Dassets
         'js/romo-av-video.js'
       ]
       assert_equal exp_js_sources, Dassets.config.combinations['js/romo-av.js']
+    end
+
+    should "only configure itself once unless reset" do
+      subject.configure!
+
+      dassets_call_count = 0
+      Assert.stub(::Dassets, :configure){ dassets_call_count += 1 }
+
+      assert_equal 0, dassets_call_count
+      subject.configure!
+      assert_equal 0, dassets_call_count
+
+      subject.reset!
+
+      assert_equal 0, dassets_call_count
+      subject.configure!
+      assert_equal 1, dassets_call_count
     end
 
   end


### PR DESCRIPTION
This is logic provided by Romo::Dassets and should similarly be
provided by Romo::Av::Dassets.  This allows for consistent Dassets
config/reset behavior between libs the use Romo/Dassets.

@jcredding ready for review.