### PR TITLE
update method organization to get up to Romo's latest convention

### DIFF
--- a/assets/js/romo-av/dropdown_video.js
+++ b/assets/js/romo-av/dropdown_video.js
@@ -7,16 +7,9 @@ $.fn.romoDropdownVideo = function() {
 var RomoDropdownVideo = function(element) {
   this.elem = $(element);
 
-  this.dropdown = this.elem.romoDropdown()[0];
-  this.doBindDropdown();
-
-  this.video = undefined;
-  this.doBindVideo();
-  this.elem.on('dropdown:loadBodySuccess', $.proxy(function(e, data, dropdown) {
-    this.doBindVideo();
-  }, this));
-
   this.doInit();
+  this._bindElem();
+
   this.elem.trigger('dropdownVideo:ready', [this]);
 }
 
@@ -24,7 +17,20 @@ RomoDropdownVideo.prototype.doInit = function() {
   // override as needed
 }
 
-RomoDropdownVideo.prototype.doBindDropdown = function() {
+// private
+
+RomoDropdownVideo.prototype._bindElem = function() {
+  this._bindDropdown();
+  this._bindVideo();
+
+  this.elem.on('dropdown:loadBodySuccess', $.proxy(function(e, data, dropdown) {
+    this._bindVideo();
+  }, this));
+}
+
+RomoDropdownVideo.prototype._bindDropdown = function() {
+  this.dropdown = this.elem.romoDropdown()[0];
+
   if (this.elem.data('romo-dropdown-clear-content') === undefined) {
     this.elem.attr('data-romo-dropdown-clear-content', 'true');
   }
@@ -82,7 +88,9 @@ RomoDropdownVideo.prototype.doBindDropdown = function() {
   }, this));
 }
 
-RomoDropdownVideo.prototype.doBindVideo = function() {
+RomoDropdownVideo.prototype._bindVideo = function() {
+  this.video = undefined;
+
   var videoElem = this.dropdown.popupElem.find('[data-romo-video-auto="dropdownVideo"]');
 
   this._bindVideoElemEvents(videoElem);
@@ -90,8 +98,6 @@ RomoDropdownVideo.prototype.doBindVideo = function() {
 
   this.video = videoElem.romoVideo()[0];
 }
-
-// private
 
 RomoDropdownVideo.prototype._bindVideoElemEvents = function(videoElem) {
   // playback events

--- a/assets/js/romo-av/modal_video.js
+++ b/assets/js/romo-av/modal_video.js
@@ -7,16 +7,9 @@ $.fn.romoModalVideo = function() {
 var RomoModalVideo = function(element) {
   this.elem = $(element);
 
-  this.modal = this.elem.romoModal()[0];
-  this.doBindModal();
-
-  this.video = undefined;
-  this.doBindVideo();
-  this.elem.on('modal:loadBodySuccess', $.proxy(function(e, data, modal) {
-    this.doBindVideo();
-  }, this));
-
   this.doInit();
+  this._bindElem();
+
   this.elem.trigger('modalVideo:ready', [this]);
 }
 
@@ -24,7 +17,20 @@ RomoModalVideo.prototype.doInit = function() {
   // override as needed
 }
 
-RomoModalVideo.prototype.doBindModal = function() {
+// private
+
+RomoModalVideo.prototype._bindElem = function() {
+  this._bindModal();
+  this._bindVideo();
+
+  this.elem.on('modal:loadBodySuccess', $.proxy(function(e, data, modal) {
+    this._bindVideo();
+  }, this));
+}
+
+RomoModalVideo.prototype._bindModal = function() {
+  this.modal = this.elem.romoModal()[0];
+
   if (this.elem.data('romo-modal-clear-content') === undefined) {
     this.elem.attr('data-romo-modal-clear-content', 'true');
   }
@@ -91,7 +97,9 @@ RomoModalVideo.prototype.doBindModal = function() {
   }, this));
 }
 
-RomoModalVideo.prototype.doBindVideo = function() {
+RomoModalVideo.prototype._bindVideo = function() {
+  this.video = undefined;
+
   var videoElem = this.modal.popupElem.find('[data-romo-video-auto="modalVideo"]');
 
   this._bindVideoElemEvents(videoElem);
@@ -99,8 +107,6 @@ RomoModalVideo.prototype.doBindVideo = function() {
 
   this.video = videoElem.romoVideo()[0];
 }
-
-// private
 
 RomoModalVideo.prototype._bindVideoElemEvents = function(videoElem) {
   // playback events

--- a/assets/js/romo-av/video.js
+++ b/assets/js/romo-av/video.js
@@ -5,21 +5,10 @@ $.fn.romoVideo = function() {
 }
 
 var RomoVideo = function(element) {
-  this.elem     = $(element);
-  this.videoObj = this.elem[0];
-
-  this._bindFullscreen();
-  this._bindVideo();
+  this.elem = $(element);
 
   this.doInit();
-  this._loadState();
-
-  this.durationTime   = undefined;
-  this.durationFrames = undefined;
-  this.elem.on('loadedmetadata', $.proxy(function(e) {
-    this.durationTime   = this.getDurationTime();
-    this.durationFrames = this.getDurationFrames();
-  }, this));
+  this._bindElem()
 
   this.elem.trigger('video:ready', [this.video, this]);
 }
@@ -304,74 +293,20 @@ RomoVideo.prototype.getVideoFormattedTime = function(seconds) {
 
 // private
 
-RomoVideo.prototype._setPlayback = function(newSecondNum) {
-  var durationTime = this.getDurationTime();
-  if (newSecondNum > durationTime) {
-    if (this.elem.prop('loop') === true){
-      this.videoObj.currentTime = newSecondNum - durationTime;
-    } else {
-      this.videoObj.currentTime = durationTime;
-    }
-  } else if (newSecondNum < 0) {
-    if (this.elem.prop('loop') === true){
-      this.videoObj.currentTime = (durationTime - (0 - newSecondNum));
-    } else {
-      this.videoObj.currentTime = 0;
-    }
-  } else {
-    this.videoObj.currentTime = newSecondNum;
-  }
-}
+RomoVideo.prototype._bindElem = function() {
+  this.videoObj = this.elem[0];
 
-RomoVideo.prototype._frameNumToSecondNum = function(frameNum) {
-  return frameNum / this.fps;
-}
+  this.durationTime   = undefined;
+  this.durationFrames = undefined;
+  this.elem.on('loadedmetadata', $.proxy(function(e) {
+    this.durationTime   = this.getDurationTime();
+    this.durationFrames = this.getDurationFrames();
+  }, this));
 
-RomoVideo.prototype._percentToSecondNum = function(percent) {
-  return (percent / 100) * this.getDurationTime();
-}
-
-RomoVideo.prototype._setVolume = function(value) {
-  if (value > 1) {
-    this.videoObj.volume = 1;
-  } else if (value < 0) {
-    this.videoObj.volume = 0;
-  } else {
-    this.videoObj.volume = value;
-  }
-  this.doUnmute();
-}
-
-RomoVideo.prototype._loadState = function() {
-  this.fps = this.elem.data('romo-video-fps');
-  if (this.fps && this.fps > 0) {
-    this.fpsEnabled = true;
-  } else {
-    this.fpsEnabled = false;
-  }
-  this.showMs = this.elem.data('romo-video-show-ms');
-}
-
-RomoVideo.prototype._bindFullscreen = function() {
-  var fullscreenElem = this.elem.closest(this.elem.data('romo-video-fullscreen-elem'));
-  if (fullscreenElem[0] !== undefined) {
-    this.fullscreenElem = fullscreenElem;
-  } else {
-    this.fullscreenElem = this.elem;
-  }
-
-  this._browserRequestFullscreen = this._getBrowserRequestFullscreen(this.fullscreenElem);
-  this._browserExitFullscreen    = this._getBrowserExitFullscreen();
-
-  $(document).on('fullscreenchange',       $.proxy(this._onDocumentFullscreenChange, this));
-  $(document).on('mozfullscreenchange',    $.proxy(this._onDocumentFullscreenChange, this));
-  $(document).on('msfullscreenchange',     $.proxy(this._onDocumentFullscreenChange, this));
-  $(document).on('webkitfullscreenchange', $.proxy(this._onDocumentFullscreenChange, this));
-}
-
-RomoVideo.prototype._bindVideo = function() {
+  this._bindFullscreen();
   this._bindVideoElemEvents();
   this._bindVideoTriggerEvents();
+  this._loadState();
 }
 
 RomoVideo.prototype._bindVideoElemEvents = function() {
@@ -524,6 +459,71 @@ RomoVideo.prototype._bindVideoTriggerEvents = function() {
     this.doModSource(source); return false;
   }, this));
 
+}
+
+RomoVideo.prototype._bindFullscreen = function() {
+  var fullscreenElem = this.elem.closest(this.elem.data('romo-video-fullscreen-elem'));
+  if (fullscreenElem[0] !== undefined) {
+    this.fullscreenElem = fullscreenElem;
+  } else {
+    this.fullscreenElem = this.elem;
+  }
+
+  this._browserRequestFullscreen = this._getBrowserRequestFullscreen(this.fullscreenElem);
+  this._browserExitFullscreen    = this._getBrowserExitFullscreen();
+
+  $(document).on('fullscreenchange',       $.proxy(this._onDocumentFullscreenChange, this));
+  $(document).on('mozfullscreenchange',    $.proxy(this._onDocumentFullscreenChange, this));
+  $(document).on('msfullscreenchange',     $.proxy(this._onDocumentFullscreenChange, this));
+  $(document).on('webkitfullscreenchange', $.proxy(this._onDocumentFullscreenChange, this));
+}
+
+RomoVideo.prototype._loadState = function() {
+  this.fps = this.elem.data('romo-video-fps');
+  if (this.fps && this.fps > 0) {
+    this.fpsEnabled = true;
+  } else {
+    this.fpsEnabled = false;
+  }
+  this.showMs = this.elem.data('romo-video-show-ms');
+}
+
+RomoVideo.prototype._setPlayback = function(newSecondNum) {
+  var durationTime = this.getDurationTime();
+  if (newSecondNum > durationTime) {
+    if (this.elem.prop('loop') === true){
+      this.videoObj.currentTime = newSecondNum - durationTime;
+    } else {
+      this.videoObj.currentTime = durationTime;
+    }
+  } else if (newSecondNum < 0) {
+    if (this.elem.prop('loop') === true){
+      this.videoObj.currentTime = (durationTime - (0 - newSecondNum));
+    } else {
+      this.videoObj.currentTime = 0;
+    }
+  } else {
+    this.videoObj.currentTime = newSecondNum;
+  }
+}
+
+RomoVideo.prototype._frameNumToSecondNum = function(frameNum) {
+  return frameNum / this.fps;
+}
+
+RomoVideo.prototype._percentToSecondNum = function(percent) {
+  return (percent / 100) * this.getDurationTime();
+}
+
+RomoVideo.prototype._setVolume = function(value) {
+  if (value > 1) {
+    this.videoObj.volume = 1;
+  } else if (value < 0) {
+    this.videoObj.volume = 0;
+  } else {
+    this.videoObj.volume = value;
+  }
+  this.doUnmute();
 }
 
 RomoVideo.prototype._onDocumentFullscreenChange = function(e) {


### PR DESCRIPTION
This updates the vide, modal-video, and dropdown-video components
to organize their init logic and methods to get them up to our
latest conventions for romo components.  This includes using the
leading underscore convention on all private methods.  This also
includes structuring the init logic such that `doInit` is called
early so custom config values can be set in component extensions.
Finally, this gets all the components using our `_bindElem`
convention for initializing elem behavior.

This is prep for rewriting the components in vanilla js using
Romo's new js API (ie no jquery).  I didn't want this to junk up
or noise out that effort so I'm doing it here separately instead.

@jcredding no behavior changes here - just method reorgs/renames.  Ready for review.