### PR TITLE
update to add "romo" namespacing to components, events, etc

### DIFF
--- a/assets/js/romo-av/dropdown_video.js
+++ b/assets/js/romo-av/dropdown_video.js
@@ -10,7 +10,7 @@ var RomoDropdownVideo = function(element) {
   this.doInit();
   this._bindElem();
 
-  this.elem.trigger('dropdownVideo:ready', [this]);
+  this.elem.trigger('romoDropdownVideo:ready', [this]);
 }
 
 RomoDropdownVideo.prototype.doInit = function() {
@@ -23,13 +23,13 @@ RomoDropdownVideo.prototype._bindElem = function() {
   this._bindDropdown();
   this._bindVideo();
 
-  this.elem.on('dropdown:loadBodySuccess', $.proxy(function(e, data, dropdown) {
+  this.elem.on('romoDropdown:loadBodySuccess', $.proxy(function(e, data, romoDropdown) {
     this._bindVideo();
   }, this));
 }
 
 RomoDropdownVideo.prototype._bindDropdown = function() {
-  this.dropdown = this.elem.romoDropdown()[0];
+  this.romoDropdown = this.elem.romoDropdown()[0];
 
   if (this.elem.data('romo-dropdown-clear-content') === undefined) {
     this.elem.attr('data-romo-dropdown-clear-content', 'true');
@@ -37,269 +37,269 @@ RomoDropdownVideo.prototype._bindDropdown = function() {
 
   // dropdown/video interactions
 
-  this.elem.on('dropdownVideo:video:loadedmetadata', $.proxy(function(e, videoObj, video, dropdownVideo) {
-    this.dropdown.doPlacePopupElem();
+  this.elem.on('romoDropdownVideo:romoVideo:loadedmetadata', $.proxy(function(e, videoObj, romoVideo, romoDropdownVideo) {
+    this.romoDropdown.doPlacePopupElem();
   }, this));
 
-  this.elem.on('dropdownVideo:video:enterFullscreen', $.proxy(function(e, videoObj, video, dropdownVideo) {
+  this.elem.on('romoDropdownVideo:romoVideo:enterFullscreen', $.proxy(function(e, videoObj, romoVideo, romoDropdownVideo) {
     // wait 1 sec then turn off dropdown body elem events - since we are in fullscreen
     // mode, we don't care about them
     setTimeout($.proxy(function() {
-      this.dropdown.doUnBindWindowBodyClick();
-      this.dropdown.doUnBindWindowBodyKeyUp();
-      this.dropdown.doUnBindElemKeyUp();
+      this.romoDropdown.doUnBindWindowBodyClick();
+      this.romoDropdown.doUnBindWindowBodyKeyUp();
+      this.romoDropdown.doUnBindElemKeyUp();
     }, this), 1000);
   }, this));
-  this.elem.on('dropdownVideo:video:exitFullscreen', $.proxy(function(e, videoObj, video, dropdownVideo) {
+  this.elem.on('romoDropdownVideo:romoVideo:exitFullscreen', $.proxy(function(e, videoObj, romoVideo, romoDropdownVideo) {
     // wait 1 sec then turn on dropdown body elem events - since we are no longer
     // in fullscreen mode, we need to care about them again
     setTimeout($.proxy(function() {
-      this.dropdown.doBindWindowBodyClick();
-      this.dropdown.doBindWindowBodyKeyUp();
-      this.dropdown.doBindElemKeyUp();
+      this.romoDropdown.doBindWindowBodyClick();
+      this.romoDropdown.doBindWindowBodyKeyUp();
+      this.romoDropdown.doBindElemKeyUp();
     }, this), 1000);
   }, this));
 
   // event proxies
 
-  this.elem.on('dropdown:ready', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownVideo:dropdown:ready', [dropdown, this]);
+  this.elem.on('romoDropdown:ready', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('romoDropdownVideo:romoDropdown:ready', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:toggle', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownVideo:dropdown:toggle', [dropdown, this]);
+  this.elem.on('romoDropdown:toggle', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('romoDropdownVideo:romoDropdown:toggle', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:popupOpen', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownVideo:dropdown:popupOpen', [dropdown, this]);
+  this.elem.on('romoDropdown:popupOpen', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('romoDropdownVideo:romoDropdown:popupOpen', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownVideo:dropdown:popupClose', [dropdown, this]);
+  this.elem.on('romoDropdown:popupClose', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('romoDropdownVideo:romoDropdown:popupClose', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:loadBodyStart', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownVideo:dropdown:loadBodyStart', [dropdown, this]);
+  this.elem.on('romoDropdown:loadBodyStart', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('romoDropdownVideo:romoDropdown:loadBodyStart', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:loadBodySuccess', $.proxy(function(e, data, dropdown) {
-    this.elem.trigger('dropdownVideo:dropdown:loadBodySuccess', [data, dropdown, this]);
+  this.elem.on('romoDropdown:loadBodySuccess', $.proxy(function(e, data, romoDropdown) {
+    this.elem.trigger('romoDropdownVideo:romoDropdown:loadBodySuccess', [data, romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:loadBodyError', $.proxy(function(e, xhr, dropdown) {
-    this.elem.trigger('dropdownVideo:dropdown:loadBodyError', [xhr, dropdown, this]);
+  this.elem.on('romoDropdown:loadBodyError', $.proxy(function(e, xhr, romoDropdown) {
+    this.elem.trigger('romoDropdownVideo:romoDropdown:loadBodyError', [xhr, romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:dismiss', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownVideo:dropdown:dismiss', [dropdown, this]);
+  this.elem.on('romoDropdown:dismiss', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('romoDropdownVideo:romoDropdown:dismiss', [romoDropdown, this]);
   }, this));
 }
 
 RomoDropdownVideo.prototype._bindVideo = function() {
-  this.video = undefined;
+  this.romoVideo = undefined;
 
-  var videoElem = this.dropdown.popupElem.find('[data-romo-video-auto="dropdownVideo"]');
+  var videoElem = this.romoDropdown.popupElem.find('[data-romo-video-auto="dropdownVideo"]');
 
   this._bindVideoElemEvents(videoElem);
   this._bindDropdownVideoTriggerEvents();
 
-  this.video = videoElem.romoVideo()[0];
+  this.romoVideo = videoElem.romoVideo()[0];
 }
 
 RomoDropdownVideo.prototype._bindVideoElemEvents = function(videoElem) {
   // playback events
 
-  videoElem.on('video:play', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:play', [videoObj, video, this]);
+  videoElem.on('romoVideo:play', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:play', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:pause', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:pause', [videoObj, video, this]);
+  videoElem.on('romoVideo:pause', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:pause', [videoObj, romoVideo, this]);
   }, this));
 
   // state events
 
-  videoElem.on('video:playing', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:playing', [videoObj, video, this]);
+  videoElem.on('romoVideo:playing', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:playing', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:waiting', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:waiting', [videoObj, video, this]);
+  videoElem.on('romoVideo:waiting', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:waiting', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:ended',  $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:ended', [videoObj, video, this]);
+  videoElem.on('romoVideo:ended',  $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:ended', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:emptied', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:emptied', [videoObj, video, this]);
+  videoElem.on('romoVideo:emptied', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:emptied', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:error', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:error', [videoObj, video, this]);
+  videoElem.on('romoVideo:error', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:error', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:stalled', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:stalled', [videoObj, video, this]);
+  videoElem.on('romoVideo:stalled', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:stalled', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:suspend', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:suspend', [videoObj, video, this]);
+  videoElem.on('romoVideo:suspend', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:suspend', [videoObj, romoVideo, this]);
   }, this));
 
   // status events
 
-  videoElem.on('video:progress', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:progress', [videoObj, video, this]);
+  videoElem.on('romoVideo:progress', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:progress', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:timeupdate', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:timeupdate', [videoObj, video, this]);
+  videoElem.on('romoVideo:timeupdate', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:timeupdate', [videoObj, romoVideo, this]);
   }, this));
 
   // settings events
 
-  videoElem.on('video:volumechange', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:volumechange', [videoObj, video, this]);
+  videoElem.on('romoVideo:volumechange', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:volumechange', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:durationchange', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:durationchange', [videoObj, video, this]);
+  videoElem.on('romoVideo:durationchange', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:durationchange', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:ratechange', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:ratechange', [videoObj, video, this]);
+  videoElem.on('romoVideo:ratechange', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:ratechange', [videoObj, romoVideo, this]);
   }, this));
 
   // fullscreen events
 
-  videoElem.on('video:enterFullscreen', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:enterFullscreen', [videoObj, video, this]);
+  videoElem.on('romoVideo:enterFullscreen', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:enterFullscreen', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:exitFullscreen', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:exitFullscreen', [videoObj, video, this]);
+  videoElem.on('romoVideo:exitFullscreen', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:exitFullscreen', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:fullscreenChange', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:fullscreenChange', [videoObj, video, this]);
+  videoElem.on('romoVideo:fullscreenChange', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:fullscreenChange', [videoObj, romoVideo, this]);
   }, this));
 
   // load events
 
-  videoElem.on('video:loadstart', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:loadstart', [videoObj, video, this]);
+  videoElem.on('romoVideo:loadstart', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:loadstart', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:loadedmetadata', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:loadedmetadata', [videoObj, video, this]);
+  videoElem.on('romoVideo:loadedmetadata', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:loadedmetadata', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:loadeddata', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:loadeddata', [videoObj, video, this]);
+  videoElem.on('romoVideo:loadeddata', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:loadeddata', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:canplay', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:canplay', [videoObj, video, this]);
+  videoElem.on('romoVideo:canplay', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:canplay', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:canplaythrough', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('dropdownVideo:video:canplaythrough', [videoObj, video, this]);
+  videoElem.on('romoVideo:canplaythrough', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoDropdownVideo:romoVideo:canplaythrough', [videoObj, romoVideo, this]);
   }, this));
 }
 
 RomoDropdownVideo.prototype._bindDropdownVideoTriggerEvents = function() {
   // playback triggers
 
-  this.elem.on('dropdownVideo:video:triggerPlay', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerPlay', []);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerPlay', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerPlay', []);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerPause', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerPause', []);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerPause', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerPause', []);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerTogglePlay', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerTogglePlay', []);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerTogglePlay', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerTogglePlay', []);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerSetPlaybackToTime', $.proxy(function(e, secondNum) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerSetPlaybackToTime', [secondNum]);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerSetPlaybackToTime', $.proxy(function(e, secondNum) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackToTime', [secondNum]);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerSetPlaybackToFrame', $.proxy(function(e, frameNum) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerSetPlaybackToFrame', [frameNum]);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerSetPlaybackToFrame', $.proxy(function(e, frameNum) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackToFrame', [frameNum]);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerSetPlaybackToPercent', $.proxy(function(e, percent) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerSetPlaybackToPercent', [percent]);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerSetPlaybackToPercent', $.proxy(function(e, percent) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackToPercent', [percent]);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerModPlaybackByTime', $.proxy(function(e, secondsCount) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModPlaybackByTime', [secondsCount]);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerModPlaybackByTime', $.proxy(function(e, secondsCount) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackByTime', [secondsCount]);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerModPlaybackByFrames', $.proxy(function(e, frameCount) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModPlaybackByFrames', [frameCount]);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerModPlaybackByFrames', $.proxy(function(e, frameCount) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackByFrames', [frameCount]);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerModPlaybackByPercent', $.proxy(function(e, percent) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModPlaybackByPercent', [percent]);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerModPlaybackByPercent', $.proxy(function(e, percent) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackByPercent', [percent]);
     }
   }, this));
 
   // settings triggers
 
-  this.elem.on('dropdownVideo:video:triggerMute', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerMute', []);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerMute', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerMute', []);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerUnmute', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerUnmute', []);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerUnmute', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerUnmute', []);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerToggleMute', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerToggleMute', []);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerToggleMute', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerToggleMute', []);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerSetVolumeToPercent', $.proxy(function(e, percent) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerSetVolumeToPercent', [percent]);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerSetVolumeToPercent', $.proxy(function(e, percent) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerSetVolumeToPercent', [percent]);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerModVolumeByPercent', $.proxy(function(e, percent) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModVolumeByPercent', [percent]);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerModVolumeByPercent', $.proxy(function(e, percent) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModVolumeByPercent', [percent]);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerSetPlaybackRate', $.proxy(function(e, rate) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerSetPlaybackRate', [rate]);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerSetPlaybackRate', $.proxy(function(e, rate) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackRate', [rate]);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerModPlaybackRate', $.proxy(function(e, rate) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModPlaybackRate', [rate]);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerModPlaybackRate', $.proxy(function(e, rate) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackRate', [rate]);
     }
   }, this));
 
   // fullscreen triggers
 
-  this.elem.on('dropdownVideo:video:triggerEnterFullscreen', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerEnterFullscreen', []);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerEnterFullscreen', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerEnterFullscreen', []);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerExitFullscreen', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerExitFullscreen', []);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerExitFullscreen', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerExitFullscreen', []);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerToggleFullscreen', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerToggleFullscreen', []);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerToggleFullscreen', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerToggleFullscreen', []);
     }
   }, this));
 
   // load triggers
 
-  this.elem.on('dropdownVideo:video:triggerLoad', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerLoad', []);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerLoad', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerLoad', []);
     }
   }, this));
-  this.elem.on('dropdownVideo:video:triggerModSource', $.proxy(function(e, source) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModSource', [source]);
+  this.elem.on('romoDropdownVideo:romoVideo:triggerModSource', $.proxy(function(e, source) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModSource', [source]);
     }
   }, this));
 }

--- a/assets/js/romo-av/modal_video.js
+++ b/assets/js/romo-av/modal_video.js
@@ -10,7 +10,7 @@ var RomoModalVideo = function(element) {
   this.doInit();
   this._bindElem();
 
-  this.elem.trigger('modalVideo:ready', [this]);
+  this.elem.trigger('romoModalVideo:ready', [this]);
 }
 
 RomoModalVideo.prototype.doInit = function() {
@@ -23,13 +23,13 @@ RomoModalVideo.prototype._bindElem = function() {
   this._bindModal();
   this._bindVideo();
 
-  this.elem.on('modal:loadBodySuccess', $.proxy(function(e, data, modal) {
+  this.elem.on('romoModal:loadBodySuccess', $.proxy(function(e, data, romoModal) {
     this._bindVideo();
   }, this));
 }
 
 RomoModalVideo.prototype._bindModal = function() {
-  this.modal = this.elem.romoModal()[0];
+  this.romoModal = this.elem.romoModal()[0];
 
   if (this.elem.data('romo-modal-clear-content') === undefined) {
     this.elem.attr('data-romo-modal-clear-content', 'true');
@@ -37,278 +37,278 @@ RomoModalVideo.prototype._bindModal = function() {
 
   // modal/video interactions
 
-  this.elem.on('modalVideo:video:loadedmetadata', $.proxy(function(e, videoObj, video, modalVideo) {
-    this.modal.doPlacePopupElem();
+  this.elem.on('romoModalVideo:romoVideo:loadedmetadata', $.proxy(function(e, videoObj, romoVideo, romoModalVideo) {
+    this.romoModal.doPlacePopupElem();
   }, this));
 
-  this.elem.on('modalVideo:video:enterFullscreen', $.proxy(function(e, videoObj, video, modalVideo) {
+  this.elem.on('romoModalVideo:romoVideo:enterFullscreen', $.proxy(function(e, videoObj, romoVideo, romoModalVideo) {
     // wait 1 sec then turn off modal body elem events - since we are in fullscreen
     // mode, we don't care about them
     setTimeout($.proxy(function() {
-      this.modal.doUnBindWindowBodyClick();
-      this.modal.doUnBindWindowBodyKeyUp();
-      this.modal.doUnBindElemKeyUp();
+      this.romoModal.doUnBindWindowBodyClick();
+      this.romoModal.doUnBindWindowBodyKeyUp();
+      this.romoModal.doUnBindElemKeyUp();
     }, this), 1000);
   }, this));
-  this.elem.on('modalVideo:video:exitFullscreen', $.proxy(function(e, videoObj, video, modalVideo) {
+  this.elem.on('romoModalVideo:romoVideo:exitFullscreen', $.proxy(function(e, videoObj, romoVideo, romoModalVideo) {
     // wait 1 sec then turn on modal body elem events - since we are no longer
     // in fullscreen mode, we need to care about them again
     setTimeout($.proxy(function() {
-      this.modal.doBindWindowBodyClick();
-      this.modal.doBindWindowBodyKeyUp();
-      this.modal.doBindElemKeyUp();
+      this.romoModal.doBindWindowBodyClick();
+      this.romoModal.doBindWindowBodyKeyUp();
+      this.romoModal.doBindElemKeyUp();
     }, this), 1000);
   }, this));
 
   // event proxies
 
-  this.elem.on('modal:ready', $.proxy(function(e, modal) {
-    this.elem.trigger('modalVideo:modal:ready', [modal, this]);
+  this.elem.on('romoModal:ready', $.proxy(function(e, romoModal) {
+    this.elem.trigger('romoModalVideo:romoModal:ready', [romoModal, this]);
   }, this));
-  this.elem.on('modal:toggle', $.proxy(function(e, modal) {
-    this.elem.trigger('modalVideo:modal:toggle', [modal, this]);
+  this.elem.on('romoModal:toggle', $.proxy(function(e, romoModal) {
+    this.elem.trigger('romoModalVideo:romoModal:toggle', [romoModal, this]);
   }, this));
-  this.elem.on('modal:popupOpen', $.proxy(function(e, modal) {
-    this.elem.trigger('modalVideo:modal:popupOpen', [modal, this]);
+  this.elem.on('romoModal:popupOpen', $.proxy(function(e, romoModal) {
+    this.elem.trigger('romoModalVideo:romoModal:popupOpen', [romoModal, this]);
   }, this));
-  this.elem.on('modal:popupClose', $.proxy(function(e, modal) {
-    this.elem.trigger('modalVideo:modal:popupClose', [modal, this]);
+  this.elem.on('romoModal:popupClose', $.proxy(function(e, romoModal) {
+    this.elem.trigger('romoModalVideo:romoModal:popupClose', [romoModal, this]);
   }, this));
-  this.elem.on('modal:dragStart', $.proxy(function(e, modal) {
-    this.elem.trigger('modalVideo:modal:dragStart', [modal, this]);
+  this.elem.on('romoModal:dragStart', $.proxy(function(e, romoModal) {
+    this.elem.trigger('romoModalVideo:romoModal:dragStart', [romoModal, this]);
   }, this));
-  this.elem.on('modal:dragMove', $.proxy(function(e, placeX, placeY, modal) {
-    this.elem.trigger('modalVideo:modal:dragMove', [placeX, placeY, modal, this]);
+  this.elem.on('romoModal:dragMove', $.proxy(function(e, placeX, placeY, romoModal) {
+    this.elem.trigger('romoModalVideo:romoModal:dragMove', [placeX, placeY, romoModal, this]);
   }, this));
-  this.elem.on('modal:dragStop', $.proxy(function(e, modal) {
-    this.elem.trigger('modalVideo:modal:dragStop', [modal, this]);
+  this.elem.on('romoModal:dragStop', $.proxy(function(e, romoModal) {
+    this.elem.trigger('romoModalVideo:romoModal:dragStop', [romoModal, this]);
   }, this));
-  this.elem.on('modal:loadBodyStart', $.proxy(function(e, modal) {
-    this.elem.trigger('modalVideo:modal:loadBodyStart', [modal, this]);
+  this.elem.on('romoModal:loadBodyStart', $.proxy(function(e, romoModal) {
+    this.elem.trigger('romoModalVideo:romoModal:loadBodyStart', [romoModal, this]);
   }, this));
-  this.elem.on('modal:loadBodySuccess', $.proxy(function(e, data, modal) {
-    this.elem.trigger('modalVideo:modal:loadBodySuccess', [data, modal, this]);
+  this.elem.on('romoModal:loadBodySuccess', $.proxy(function(e, data, romoModal) {
+    this.elem.trigger('romoModalVideo:romoModal:loadBodySuccess', [data, romoModal, this]);
   }, this));
-  this.elem.on('modal:loadBodyError', $.proxy(function(e, xhr, modal) {
-    this.elem.trigger('modalVideo:modal:loadBodyError', [xhr, modal, this]);
+  this.elem.on('romoModal:loadBodyError', $.proxy(function(e, xhr, romoModal) {
+    this.elem.trigger('romoModalVideo:romoModal:loadBodyError', [xhr, romoModal, this]);
   }, this));
-  this.elem.on('modal:dismiss', $.proxy(function(e, modal) {
-    this.elem.trigger('modalVideo:modal:dismiss', [modal, this]);
+  this.elem.on('romoModal:dismiss', $.proxy(function(e, romoModal) {
+    this.elem.trigger('romoModalVideo:romoModal:dismiss', [romoModal, this]);
   }, this));
 }
 
 RomoModalVideo.prototype._bindVideo = function() {
-  this.video = undefined;
+  this.romoVideo = undefined;
 
-  var videoElem = this.modal.popupElem.find('[data-romo-video-auto="modalVideo"]');
+  var videoElem = this.romoModal.popupElem.find('[data-romo-video-auto="modalVideo"]');
 
   this._bindVideoElemEvents(videoElem);
   this._bindModalVideoTriggerEvents();
 
-  this.video = videoElem.romoVideo()[0];
+  this.romoVideo = videoElem.romoVideo()[0];
 }
 
 RomoModalVideo.prototype._bindVideoElemEvents = function(videoElem) {
   // playback events
 
-  videoElem.on('video:play', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:play', [videoObj, video, this]);
+  videoElem.on('romoVideo:play', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:play', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:pause', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:pause', [videoObj, video, this]);
+  videoElem.on('romoVideo:pause', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:pause', [videoObj, romoVideo, this]);
   }, this));
 
   // state events
 
-  videoElem.on('video:playing', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:playing', [videoObj, video, this]);
+  videoElem.on('romoVideo:playing', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:playing', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:waiting', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:waiting', [videoObj, video, this]);
+  videoElem.on('romoVideo:waiting', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:waiting', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:ended',  $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:ended', [videoObj, video, this]);
+  videoElem.on('romoVideo:ended',  $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:ended', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:emptied', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:emptied', [videoObj, video, this]);
+  videoElem.on('romoVideo:emptied', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:emptied', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:error', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:error', [videoObj, video, this]);
+  videoElem.on('romoVideo:error', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:error', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:stalled', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:stalled', [videoObj, video, this]);
+  videoElem.on('romoVideo:stalled', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:stalled', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:suspend', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:suspend', [videoObj, video, this]);
+  videoElem.on('romoVideo:suspend', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:suspend', [videoObj, romoVideo, this]);
   }, this));
 
   // status events
 
-  videoElem.on('video:progress', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:progress', [videoObj, video, this]);
+  videoElem.on('romoVideo:progress', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:progress', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:timeupdate', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:timeupdate', [videoObj, video, this]);
+  videoElem.on('romoVideo:timeupdate', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:timeupdate', [videoObj, romoVideo, this]);
   }, this));
 
   // settings events
 
-  videoElem.on('video:volumechange', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:volumechange', [videoObj, video, this]);
+  videoElem.on('romoVideo:volumechange', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:volumechange', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:durationchange', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:durationchange', [videoObj, video, this]);
+  videoElem.on('romoVideo:durationchange', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:durationchange', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:ratechange', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:ratechange', [videoObj, video, this]);
+  videoElem.on('romoVideo:ratechange', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:ratechange', [videoObj, romoVideo, this]);
   }, this));
 
   // fullscreen events
 
-  videoElem.on('video:enterFullscreen', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:enterFullscreen', [videoObj, video, this]);
+  videoElem.on('romoVideo:enterFullscreen', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:enterFullscreen', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:exitFullscreen', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:exitFullscreen', [videoObj, video, this]);
+  videoElem.on('romoVideo:exitFullscreen', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:exitFullscreen', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:fullscreenChange', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:fullscreenChange', [videoObj, video, this]);
+  videoElem.on('romoVideo:fullscreenChange', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:fullscreenChange', [videoObj, romoVideo, this]);
   }, this));
 
   // load events
 
-  videoElem.on('video:loadstart', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:loadstart', [videoObj, video, this]);
+  videoElem.on('romoVideo:loadstart', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:loadstart', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:loadedmetadata', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:loadedmetadata', [videoObj, video, this]);
+  videoElem.on('romoVideo:loadedmetadata', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:loadedmetadata', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:loadeddata', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:loadeddata', [videoObj, video, this]);
+  videoElem.on('romoVideo:loadeddata', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:loadeddata', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:canplay', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:canplay', [videoObj, video, this]);
+  videoElem.on('romoVideo:canplay', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:canplay', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('video:canplaythrough', $.proxy(function(e, videoObj, video) {
-    this.elem.trigger('modalVideo:video:canplaythrough', [videoObj, video, this]);
+  videoElem.on('romoVideo:canplaythrough', $.proxy(function(e, videoObj, romoVideo) {
+    this.elem.trigger('romoModalVideo:romoVideo:canplaythrough', [videoObj, romoVideo, this]);
   }, this));
 }
 
 RomoModalVideo.prototype._bindModalVideoTriggerEvents = function() {
   // playback triggers
 
-  this.elem.on('modalVideo:video:triggerPlay', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerPlay', []);
+  this.elem.on('romoModalVideo:romoVideo:triggerPlay', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerPlay', []);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerPause', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerPause', []);
+  this.elem.on('romoModalVideo:romoVideo:triggerPause', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerPause', []);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerTogglePlay', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerTogglePlay', []);
+  this.elem.on('romoModalVideo:romoVideo:triggerTogglePlay', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerTogglePlay', []);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerSetPlaybackToTime', $.proxy(function(e, secondNum) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerSetPlaybackToTime', [secondNum]);
+  this.elem.on('romoModalVideo:romoVideo:triggerSetPlaybackToTime', $.proxy(function(e, secondNum) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackToTime', [secondNum]);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerSetPlaybackToFrame', $.proxy(function(e, frameNum) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerSetPlaybackToFrame', [frameNum]);
+  this.elem.on('romoModalVideo:romoVideo:triggerSetPlaybackToFrame', $.proxy(function(e, frameNum) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackToFrame', [frameNum]);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerSetPlaybackToPercent', $.proxy(function(e, percent) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerSetPlaybackToPercent', [percent]);
+  this.elem.on('romoModalVideo:romoVideo:triggerSetPlaybackToPercent', $.proxy(function(e, percent) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackToPercent', [percent]);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerModPlaybackByTime', $.proxy(function(e, secondsCount) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModPlaybackByTime', [secondsCount]);
+  this.elem.on('romoModalVideo:romoVideo:triggerModPlaybackByTime', $.proxy(function(e, secondsCount) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackByTime', [secondsCount]);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerModPlaybackByFrames', $.proxy(function(e, frameCount) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModPlaybackByFrames', [frameCount]);
+  this.elem.on('romoModalVideo:romoVideo:triggerModPlaybackByFrames', $.proxy(function(e, frameCount) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackByFrames', [frameCount]);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerModPlaybackByPercent', $.proxy(function(e, percent) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModPlaybackByPercent', [percent]);
+  this.elem.on('romoModalVideo:romoVideo:triggerModPlaybackByPercent', $.proxy(function(e, percent) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackByPercent', [percent]);
     }
   }, this));
 
   // settings triggers
 
-  this.elem.on('modalVideo:video:triggerMute', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerMute', []);
+  this.elem.on('romoModalVideo:romoVideo:triggerMute', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerMute', []);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerUnmute', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerUnmute', []);
+  this.elem.on('romoModalVideo:romoVideo:triggerUnmute', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerUnmute', []);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerToggleMute', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerToggleMute', []);
+  this.elem.on('romoModalVideo:romoVideo:triggerToggleMute', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerToggleMute', []);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerSetVolumeToPercent', $.proxy(function(e, percent) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerSetVolumeToPercent', [percent]);
+  this.elem.on('romoModalVideo:romoVideo:triggerSetVolumeToPercent', $.proxy(function(e, percent) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerSetVolumeToPercent', [percent]);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerModVolumeByPercent', $.proxy(function(e, percent) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModVolumeByPercent', [percent]);
+  this.elem.on('romoModalVideo:romoVideo:triggerModVolumeByPercent', $.proxy(function(e, percent) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModVolumeByPercent', [percent]);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerSetPlaybackRate', $.proxy(function(e, rate) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerSetPlaybackRate', [rate]);
+  this.elem.on('romoModalVideo:romoVideo:triggerSetPlaybackRate', $.proxy(function(e, rate) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackRate', [rate]);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerModPlaybackRate', $.proxy(function(e, rate) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModPlaybackRate', [rate]);
+  this.elem.on('romoModalVideo:romoVideo:triggerModPlaybackRate', $.proxy(function(e, rate) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackRate', [rate]);
     }
   }, this));
 
   // fullscreen triggers
 
-  this.elem.on('modalVideo:video:triggerEnterFullscreen', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerEnterFullscreen', []);
+  this.elem.on('romoModalVideo:romoVideo:triggerEnterFullscreen', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerEnterFullscreen', []);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerExitFullscreen', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerExitFullscreen', []);
+  this.elem.on('romoModalVideo:romoVideo:triggerExitFullscreen', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerExitFullscreen', []);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerToggleFullscreen', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerToggleFullscreen', []);
+  this.elem.on('romoModalVideo:romoVideo:triggerToggleFullscreen', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerToggleFullscreen', []);
     }
   }, this));
 
   // load triggers
 
-  this.elem.on('modalVideo:video:triggerLoad', $.proxy(function(e) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerLoad', []);
+  this.elem.on('romoModalVideo:romoVideo:triggerLoad', $.proxy(function(e) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerLoad', []);
     }
   }, this));
-  this.elem.on('modalVideo:video:triggerModSource', $.proxy(function(e, source) {
-    if (this.video != undefined) {
-      this.video.elem.trigger('video:triggerModSource', [source]);
+  this.elem.on('romoModalVideo:romoVideo:triggerModSource', $.proxy(function(e, source) {
+    if (this.romoVideo != undefined) {
+      this.romoVideo.elem.trigger('romoVideo:triggerModSource', [source]);
     }
   }, this));
 }

--- a/assets/js/romo-av/video.js
+++ b/assets/js/romo-av/video.js
@@ -10,7 +10,7 @@ var RomoVideo = function(element) {
   this.doInit();
   this._bindElem()
 
-  this.elem.trigger('video:ready', [this.video, this]);
+  this.elem.trigger('romoVideo:ready', [this.videoObj, this]);
 }
 
 RomoVideo.prototype.doInit = function() {
@@ -65,17 +65,17 @@ RomoVideo.prototype.doModPlaybackByPercent = function(percent) {
 
 RomoVideo.prototype.doMute = function() {
   this.videoObj.muted = true;
-  this.elem.trigger('video:volumechange', [this.videoObj, this]);
+  this.elem.trigger('romoVideo:volumechange', [this.videoObj, this]);
 }
 
 RomoVideo.prototype.doUnmute = function() {
   this.videoObj.muted = false;
-  this.elem.trigger('video:volumechange', [this.videoObj, this]);
+  this.elem.trigger('romoVideo:volumechange', [this.videoObj, this]);
 }
 
 RomoVideo.prototype.doToggleMute = function() {
   this.videoObj.muted = !this.videoObj.muted;
-  this.elem.trigger('video:volumechange', [this.videoObj, this]);
+  this.elem.trigger('romoVideo:volumechange', [this.videoObj, this]);
 }
 
 RomoVideo.prototype.getLoop = function() {
@@ -84,14 +84,14 @@ RomoVideo.prototype.getLoop = function() {
 
 RomoVideo.prototype.doLoop = function() {
   this.elem.prop('loop', true);
-  this.elem.trigger('video:loop',       [this.videoObj, this]);
-  this.elem.trigger('video:loopChange', [true, this.videoObj, this]);
+  this.elem.trigger('romoVideo:loop',       [this.videoObj, this]);
+  this.elem.trigger('romoVideo:loopChange', [true, this.videoObj, this]);
 }
 
 RomoVideo.prototype.doNoLoop = function() {
   this.elem.prop('loop', false);
-  this.elem.trigger('video:noloop',     [this.videoObj, this]);
-  this.elem.trigger('video:loopChange', [false, this.videoObj, this]);
+  this.elem.trigger('romoVideo:noloop',     [this.videoObj, this]);
+  this.elem.trigger('romoVideo:loopChange', [false, this.videoObj, this]);
 }
 
 RomoVideo.prototype.doToggleLoop = function() {
@@ -313,149 +313,149 @@ RomoVideo.prototype._bindVideoElemEvents = function() {
   // playback events
 
   this.elem.on('play', $.proxy(function(e) {
-    this.elem.trigger('video:play', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:play', [this.videoObj, this]);
   }, this));
   this.elem.on('pause', $.proxy(function(e) {
-    this.elem.trigger('video:pause', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:pause', [this.videoObj, this]);
   }, this));
 
   // state events
 
   this.elem.on('playing', $.proxy(function(e) {
-    this.elem.trigger('video:playing', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:playing', [this.videoObj, this]);
   }, this));
   this.elem.on('waiting', $.proxy(function(e) {
-    this.elem.trigger('video:waiting', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:waiting', [this.videoObj, this]);
   }, this));
   this.elem.on('ended',  $.proxy(function(e) {
-    this.elem.trigger('video:ended', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:ended', [this.videoObj, this]);
   }, this));
   this.elem.on('emptied', $.proxy(function(e) {
-    this.elem.trigger('video:emptied', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:emptied', [this.videoObj, this]);
   }, this));
   this.elem.on('error', $.proxy(function(e) {
-    this.elem.trigger('video:error', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:error', [this.videoObj, this]);
   }, this));
   this.elem.on('stalled', $.proxy(function(e) {
-    this.elem.trigger('video:stalled', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:stalled', [this.videoObj, this]);
   }, this));
   this.elem.on('suspend', $.proxy(function(e) {
-    this.elem.trigger('video:suspend', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:suspend', [this.videoObj, this]);
   }, this));
 
   // status events
 
   this.elem.on('progress', $.proxy(function(e) {
-    this.elem.trigger('video:progress', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:progress', [this.videoObj, this]);
   }, this));
   this.elem.on('timeupdate', $.proxy(function(e) {
-    this.elem.trigger('video:timeupdate', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:timeupdate', [this.videoObj, this]);
   }, this));
 
   // settings events
 
   this.elem.on('volumechange', $.proxy(function(e) {
-    this.elem.trigger('video:volumechange', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:volumechange', [this.videoObj, this]);
   }, this));
   this.elem.on('durationchange', $.proxy(function(e) {
-    this.elem.trigger('video:durationchange', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:durationchange', [this.videoObj, this]);
   }, this));
   this.elem.on('ratechange', $.proxy(function(e) {
-    this.elem.trigger('video:ratechange', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:ratechange', [this.videoObj, this]);
   }, this));
 
   // load events
 
   this.elem.on('loadstart', $.proxy(function(e) {
-    this.elem.trigger('video:loadstart', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:loadstart', [this.videoObj, this]);
   }, this));
   this.elem.on('loadedmetadata', $.proxy(function(e) {
-    this.elem.trigger('video:loadedmetadata', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:loadedmetadata', [this.videoObj, this]);
   }, this));
   this.elem.on('loadeddata', $.proxy(function(e) {
-    this.elem.trigger('video:loadeddata', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:loadeddata', [this.videoObj, this]);
   }, this));
   this.elem.on('canplay', $.proxy(function(e) {
-    this.elem.trigger('video:canplay', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:canplay', [this.videoObj, this]);
   }, this));
   this.elem.on('canplaythrough', $.proxy(function(e) {
-    this.elem.trigger('video:canplaythrough', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:canplaythrough', [this.videoObj, this]);
   }, this));
 }
 
 RomoVideo.prototype._bindVideoTriggerEvents = function() {
   // playback triggers
 
-  this.elem.on('video:triggerPlay', $.proxy(function(e) {
+  this.elem.on('romoVideo:triggerPlay', $.proxy(function(e) {
     this.doPlay(); return false;
   }, this));
-  this.elem.on('video:triggerPause', $.proxy(function(e) {
+  this.elem.on('romoVideo:triggerPause', $.proxy(function(e) {
     this.doPause(); return false;
   }, this));
-  this.elem.on('video:triggerTogglePlay', $.proxy(function(e) {
+  this.elem.on('romoVideo:triggerTogglePlay', $.proxy(function(e) {
     this.doTogglePlay(); return false;
   }, this));
-  this.elem.on('video:triggerSetPlaybackToTime', $.proxy(function(e, secondNum) {
+  this.elem.on('romoVideo:triggerSetPlaybackToTime', $.proxy(function(e, secondNum) {
     this.doSetPlaybackToTime(secondNum); return false;
   }, this));
-  this.elem.on('video:triggerSetPlaybackToFrame', $.proxy(function(e, frameNum) {
+  this.elem.on('romoVideo:triggerSetPlaybackToFrame', $.proxy(function(e, frameNum) {
     this.doSetPlaybackToFrame(frameNum); return false;
   }, this));
-  this.elem.on('video:triggerSetPlaybackToPercent', $.proxy(function(e, percent) {
+  this.elem.on('romoVideo:triggerSetPlaybackToPercent', $.proxy(function(e, percent) {
     this.doSetPlaybackToPercent(percent); return false;
   }, this));
-  this.elem.on('video:triggerModPlaybackByTime', $.proxy(function(e, secondsCount) {
+  this.elem.on('romoVideo:triggerModPlaybackByTime', $.proxy(function(e, secondsCount) {
     this.doModPlaybackByTime(secondsCount); return false;
   }, this));
-  this.elem.on('video:triggerModPlaybackByFrames', $.proxy(function(e, frameCount) {
+  this.elem.on('romoVideo:triggerModPlaybackByFrames', $.proxy(function(e, frameCount) {
     this.doModPlaybackByFrames(frameCount); return false;
   }, this));
-  this.elem.on('video:triggerModPlaybackByPercent', $.proxy(function(e, percent) {
+  this.elem.on('romoVideo:triggerModPlaybackByPercent', $.proxy(function(e, percent) {
     this.doModPlaybackByPercent(percent); return false;
   }, this));
 
   // settings triggers
 
-  this.elem.on('video:triggerMute', $.proxy(function(e) {
+  this.elem.on('romoVideo:triggerMute', $.proxy(function(e) {
     this.doMute(); return false;
   }, this));
-  this.elem.on('video:triggerUnmute', $.proxy(function(e) {
+  this.elem.on('romoVideo:triggerUnmute', $.proxy(function(e) {
     this.doUnmute(); return false;
   }, this));
-  this.elem.on('video:triggerToggleMute', $.proxy(function(e) {
+  this.elem.on('romoVideo:triggerToggleMute', $.proxy(function(e) {
     this.doToggleMute(); return false;
   }, this));
-  this.elem.on('video:triggerSetVolumeToPercent', $.proxy(function(e, percent) {
+  this.elem.on('romoVideo:triggerSetVolumeToPercent', $.proxy(function(e, percent) {
     this.doSetVolumeToPercent(percent); return false;
   }, this));
-  this.elem.on('video:triggerModVolumeByPercent', $.proxy(function(e, percent) {
+  this.elem.on('romoVideo:triggerModVolumeByPercent', $.proxy(function(e, percent) {
     this.doModVolumeByPercent(percent); return false;
   }, this));
-  this.elem.on('video:triggerSetPlaybackRate', $.proxy(function(e, rate) {
+  this.elem.on('romoVideo:triggerSetPlaybackRate', $.proxy(function(e, rate) {
     this.doSetPlaybackToRate(rate); return false;
   }, this));
-  this.elem.on('video:triggerModPlaybackRate', $.proxy(function(e, rate) {
+  this.elem.on('romoVideo:triggerModPlaybackRate', $.proxy(function(e, rate) {
     this.doModPlaybackByRate(rate); return false;
   }, this));
 
   // fullscreen triggers
 
-  this.elem.on('video:triggerEnterFullscreen', $.proxy(function(e) {
+  this.elem.on('romoVideo:triggerEnterFullscreen', $.proxy(function(e) {
     this.doEnterFullscreen(); return false;
   }, this));
-  this.elem.on('video:triggerExitFullscreen', $.proxy(function(e) {
+  this.elem.on('romoVideo:triggerExitFullscreen', $.proxy(function(e) {
     this.doExitFullscreen(); return false;
   }, this));
-  this.elem.on('video:triggerToggleFullscreen', $.proxy(function(e) {
+  this.elem.on('romoVideo:triggerToggleFullscreen', $.proxy(function(e) {
     this.doToggleFullscreen(); return false;
   }, this));
 
   // load triggers
 
-  this.elem.on('video:triggerLoad', $.proxy(function(e) {
+  this.elem.on('romoVideo:triggerLoad', $.proxy(function(e) {
     this.doLoad(); return false;
   }, this));
-  this.elem.on('video:triggerModSource', $.proxy(function(e, source) {
+  this.elem.on('romoVideo:triggerModSource', $.proxy(function(e, source) {
     this.doModSource(source); return false;
   }, this));
 
@@ -529,12 +529,12 @@ RomoVideo.prototype._setVolume = function(value) {
 RomoVideo.prototype._onDocumentFullscreenChange = function(e) {
   if (this._getCurrentFullscreenElem() === this.fullscreenElem[0]) {
     this.fullScreen = true;
-    this.elem.trigger('video:enterFullscreen', [this.videoObj, this]);
-    this.elem.trigger('video:fullscreenChange', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:enterFullscreen', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:fullscreenChange', [this.videoObj, this]);
   } else if (this.fullScreen === true) {
     this.fullScreen = false;
-    this.elem.trigger('video:exitFullscreen', [this.videoObj, this]);
-    this.elem.trigger('video:fullscreenChange', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:exitFullscreen', [this.videoObj, this]);
+    this.elem.trigger('romoVideo:fullscreenChange', [this.videoObj, this]);
   }
 }
 


### PR DESCRIPTION
This is part of getting romo-av up to our latest Romo conventions.
All romo events are now namespaced with "romo".  This makes them
easier to search on but also helps prevent event name collisions
with other js libs.  This helps keep Romo inter-operable with any
js framework/lib.

This also updates any of the local vars/params that contain romo
components to be named with "romo".  This helps keep things
straight about what the var actually contains.

@jcredding ready for review.