### PR TITLE
update modal video js to use Romo's new API, vanilla js

### DIFF
--- a/assets/js/romo-av/modal_video.js
+++ b/assets/js/romo-av/modal_video.js
@@ -1,11 +1,5 @@
-$.fn.romoModalVideo = function() {
-  return $.map(this, function(element) {
-    return new RomoModalVideo(element);
-  });
-}
-
-var RomoModalVideo = function(element) {
-  this.elem = $(element);
+var RomoModalVideo = function(elem) {
+  this.elem = elem;
 
   this.doInit();
   this._bindElem();
@@ -23,37 +17,37 @@ RomoModalVideo.prototype._bindElem = function() {
   this._bindModal();
   this._bindVideo();
 
-  this.elem.on('romoModal:loadBodySuccess', $.proxy(function(e, data, romoModal) {
+  Romo.on(this.elem, 'romoModal:loadBodySuccess', Romo.proxy(function(e, data, romoModal) {
     this._bindVideo();
   }, this));
 }
 
 RomoModalVideo.prototype._bindModal = function() {
-  this.romoModal = this.elem.romoModal()[0];
-
-  if (this.elem.data('romo-modal-clear-content') === undefined) {
-    this.elem.attr('data-romo-modal-clear-content', 'true');
+  if (Romo.data(this.elem, 'romo-modal-clear-content') === undefined) {
+    Romo.setData(this.elem, 'romo-modal-clear-content', 'true');
   }
+
+  this.romoModal = new RomoModal(this.elem);
 
   // modal/video interactions
 
-  this.elem.on('romoModalVideo:romoVideo:loadedmetadata', $.proxy(function(e, videoObj, romoVideo, romoModalVideo) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:loadedmetadata', Romo.proxy(function(e, videoObj, romoVideo, romoModalVideo) {
     this.romoModal.doPlacePopupElem();
   }, this));
 
-  this.elem.on('romoModalVideo:romoVideo:enterFullscreen', $.proxy(function(e, videoObj, romoVideo, romoModalVideo) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:enterFullscreen', Romo.proxy(function(e, videoObj, romoVideo, romoModalVideo) {
     // wait 1 sec then turn off modal body elem events - since we are in fullscreen
     // mode, we don't care about them
-    setTimeout($.proxy(function() {
+    setTimeout(Romo.proxy(function() {
       this.romoModal.doUnBindWindowBodyClick();
       this.romoModal.doUnBindWindowBodyKeyUp();
       this.romoModal.doUnBindElemKeyUp();
     }, this), 1000);
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:exitFullscreen', $.proxy(function(e, videoObj, romoVideo, romoModalVideo) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:exitFullscreen', Romo.proxy(function(e, videoObj, romoVideo, romoModalVideo) {
     // wait 1 sec then turn on modal body elem events - since we are no longer
     // in fullscreen mode, we need to care about them again
-    setTimeout($.proxy(function() {
+    setTimeout(Romo.proxy(function() {
       this.romoModal.doBindWindowBodyClick();
       this.romoModal.doBindWindowBodyKeyUp();
       this.romoModal.doBindElemKeyUp();
@@ -62,257 +56,258 @@ RomoModalVideo.prototype._bindModal = function() {
 
   // event proxies
 
-  this.elem.on('romoModal:ready', $.proxy(function(e, romoModal) {
-    this.elem.trigger('romoModalVideo:romoModal:ready', [romoModal, this]);
+  Romo.on(this.elem, 'romoModal:ready', Romo.proxy(function(e, romoModal) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoModal:ready', [romoModal, this]);
   }, this));
-  this.elem.on('romoModal:toggle', $.proxy(function(e, romoModal) {
-    this.elem.trigger('romoModalVideo:romoModal:toggle', [romoModal, this]);
+  Romo.on(this.elem, 'romoModal:toggle', Romo.proxy(function(e, romoModal) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoModal:toggle', [romoModal, this]);
   }, this));
-  this.elem.on('romoModal:popupOpen', $.proxy(function(e, romoModal) {
-    this.elem.trigger('romoModalVideo:romoModal:popupOpen', [romoModal, this]);
+  Romo.on(this.elem, 'romoModal:popupOpen', Romo.proxy(function(e, romoModal) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoModal:popupOpen', [romoModal, this]);
   }, this));
-  this.elem.on('romoModal:popupClose', $.proxy(function(e, romoModal) {
-    this.elem.trigger('romoModalVideo:romoModal:popupClose', [romoModal, this]);
+  Romo.on(this.elem, 'romoModal:popupClose', Romo.proxy(function(e, romoModal) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoModal:popupClose', [romoModal, this]);
   }, this));
-  this.elem.on('romoModal:dragStart', $.proxy(function(e, romoModal) {
-    this.elem.trigger('romoModalVideo:romoModal:dragStart', [romoModal, this]);
+  Romo.on(this.elem, 'romoModal:dragStart', Romo.proxy(function(e, romoModal) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoModal:dragStart', [romoModal, this]);
   }, this));
-  this.elem.on('romoModal:dragMove', $.proxy(function(e, placeX, placeY, romoModal) {
-    this.elem.trigger('romoModalVideo:romoModal:dragMove', [placeX, placeY, romoModal, this]);
+  Romo.on(this.elem, 'romoModal:dragMove', Romo.proxy(function(e, placeX, placeY, romoModal) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoModal:dragMove', [placeX, placeY, romoModal, this]);
   }, this));
-  this.elem.on('romoModal:dragStop', $.proxy(function(e, romoModal) {
-    this.elem.trigger('romoModalVideo:romoModal:dragStop', [romoModal, this]);
+  Romo.on(this.elem, 'romoModal:dragStop', Romo.proxy(function(e, romoModal) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoModal:dragStop', [romoModal, this]);
   }, this));
-  this.elem.on('romoModal:loadBodyStart', $.proxy(function(e, romoModal) {
-    this.elem.trigger('romoModalVideo:romoModal:loadBodyStart', [romoModal, this]);
+  Romo.on(this.elem, 'romoModal:loadBodyStart', Romo.proxy(function(e, romoModal) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoModal:loadBodyStart', [romoModal, this]);
   }, this));
-  this.elem.on('romoModal:loadBodySuccess', $.proxy(function(e, data, romoModal) {
-    this.elem.trigger('romoModalVideo:romoModal:loadBodySuccess', [data, romoModal, this]);
+  Romo.on(this.elem, 'romoModal:loadBodySuccess', Romo.proxy(function(e, data, romoModal) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoModal:loadBodySuccess', [data, romoModal, this]);
   }, this));
-  this.elem.on('romoModal:loadBodyError', $.proxy(function(e, xhr, romoModal) {
-    this.elem.trigger('romoModalVideo:romoModal:loadBodyError', [xhr, romoModal, this]);
+  Romo.on(this.elem, 'romoModal:loadBodyError', Romo.proxy(function(e, xhr, romoModal) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoModal:loadBodyError', [xhr, romoModal, this]);
   }, this));
-  this.elem.on('romoModal:dismiss', $.proxy(function(e, romoModal) {
-    this.elem.trigger('romoModalVideo:romoModal:dismiss', [romoModal, this]);
+  Romo.on(this.elem, 'romoModal:dismiss', Romo.proxy(function(e, romoModal) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoModal:dismiss', [romoModal, this]);
   }, this));
 }
 
 RomoModalVideo.prototype._bindVideo = function() {
   this.romoVideo = undefined;
 
-  var videoElem = this.romoModal.popupElem.find('[data-romo-video-auto="modalVideo"]');
+  var videoElem = Romo.find(this.romoModal.popupElem, '[data-romo-video-auto="modalVideo"]')[0];
+  if (videoElem !== undefined) {
+    this._bindVideoElemEvents(videoElem);
+    this._bindModalVideoTriggerEvents();
 
-  this._bindVideoElemEvents(videoElem);
-  this._bindModalVideoTriggerEvents();
-
-  this.romoVideo = videoElem.romoVideo()[0];
+    this.romoVideo = new RomoVideo(videoElem);
+  }
 }
 
 RomoModalVideo.prototype._bindVideoElemEvents = function(videoElem) {
   // playback events
 
-  videoElem.on('romoVideo:play', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:play', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:play', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:play', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:pause', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:pause', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:pause', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:pause', [videoObj, romoVideo, this]);
   }, this));
 
   // state events
 
-  videoElem.on('romoVideo:playing', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:playing', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:playing', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:playing', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:waiting', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:waiting', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:waiting', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:waiting', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:ended',  $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:ended', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:ended', Romo$.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:ended', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:emptied', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:emptied', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:emptied', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:emptied', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:error', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:error', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:error', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:error', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:stalled', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:stalled', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:stalled', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:stalled', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:suspend', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:suspend', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:suspend', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:suspend', [videoObj, romoVideo, this]);
   }, this));
 
   // status events
 
-  videoElem.on('romoVideo:progress', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:progress', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:progress', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:progress', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:timeupdate', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:timeupdate', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:timeupdate', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:timeupdate', [videoObj, romoVideo, this]);
   }, this));
 
   // settings events
 
-  videoElem.on('romoVideo:volumechange', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:volumechange', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:volumechange', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:volumechange', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:durationchange', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:durationchange', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:durationchange', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:durationchange', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:ratechange', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:ratechange', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:ratechange', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:ratechange', [videoObj, romoVideo, this]);
   }, this));
 
   // fullscreen events
 
-  videoElem.on('romoVideo:enterFullscreen', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:enterFullscreen', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:enterFullscreen', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:enterFullscreen', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:exitFullscreen', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:exitFullscreen', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:exitFullscreen', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:exitFullscreen', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:fullscreenChange', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:fullscreenChange', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:fullscreenChange', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:fullscreenChange', [videoObj, romoVideo, this]);
   }, this));
 
   // load events
 
-  videoElem.on('romoVideo:loadstart', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:loadstart', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:loadstart', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:loadstart', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:loadedmetadata', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:loadedmetadata', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:loadedmetadata', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:loadedmetadata', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:loadeddata', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:loadeddata', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:loadeddata', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:loadeddata', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:canplay', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:canplay', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:canplay', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:canplay', [videoObj, romoVideo, this]);
   }, this));
-  videoElem.on('romoVideo:canplaythrough', $.proxy(function(e, videoObj, romoVideo) {
-    this.elem.trigger('romoModalVideo:romoVideo:canplaythrough', [videoObj, romoVideo, this]);
+  Romo.on(videoElem, 'romoVideo:canplaythrough', Romo.proxy(function(e, videoObj, romoVideo) {
+    Romo.trigger(this.elem, 'romoModalVideo:romoVideo:canplaythrough', [videoObj, romoVideo, this]);
   }, this));
 }
 
 RomoModalVideo.prototype._bindModalVideoTriggerEvents = function() {
   // playback triggers
 
-  this.elem.on('romoModalVideo:romoVideo:triggerPlay', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerPlay', Romo.proxy(function(e) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerPlay', []);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerPlay', []);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerPause', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerPause', Romo.proxy(function(e) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerPause', []);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerPause', []);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerTogglePlay', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerTogglePlay', Romo.proxy(function(e) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerTogglePlay', []);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerTogglePlay', []);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerSetPlaybackToTime', $.proxy(function(e, secondNum) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerSetPlaybackToTime', Romo.proxy(function(e, secondNum) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackToTime', [secondNum]);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerSetPlaybackToTime', [secondNum]);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerSetPlaybackToFrame', $.proxy(function(e, frameNum) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerSetPlaybackToFrame', Romo.proxy(function(e, frameNum) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackToFrame', [frameNum]);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerSetPlaybackToFrame', [frameNum]);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerSetPlaybackToPercent', $.proxy(function(e, percent) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerSetPlaybackToPercent', Romo.proxy(function(e, percent) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackToPercent', [percent]);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerSetPlaybackToPercent', [percent]);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerModPlaybackByTime', $.proxy(function(e, secondsCount) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerModPlaybackByTime', Romo.proxy(function(e, secondsCount) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackByTime', [secondsCount]);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerModPlaybackByTime', [secondsCount]);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerModPlaybackByFrames', $.proxy(function(e, frameCount) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerModPlaybackByFrames', Romo.proxy(function(e, frameCount) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackByFrames', [frameCount]);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerModPlaybackByFrames', [frameCount]);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerModPlaybackByPercent', $.proxy(function(e, percent) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerModPlaybackByPercent', Romo.proxy(function(e, percent) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackByPercent', [percent]);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerModPlaybackByPercent', [percent]);
     }
   }, this));
 
   // settings triggers
 
-  this.elem.on('romoModalVideo:romoVideo:triggerMute', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerMute', Romo.proxy(function(e) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerMute', []);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerMute', []);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerUnmute', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerUnmute', Romo.proxy(function(e) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerUnmute', []);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerUnmute', []);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerToggleMute', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerToggleMute', Romo.proxy(function(e) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerToggleMute', []);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerToggleMute', []);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerSetVolumeToPercent', $.proxy(function(e, percent) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerSetVolumeToPercent', Romo.proxy(function(e, percent) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerSetVolumeToPercent', [percent]);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerSetVolumeToPercent', [percent]);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerModVolumeByPercent', $.proxy(function(e, percent) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerModVolumeByPercent', Romo.proxy(function(e, percent) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerModVolumeByPercent', [percent]);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerModVolumeByPercent', [percent]);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerSetPlaybackRate', $.proxy(function(e, rate) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerSetPlaybackRate', Romo.proxy(function(e, rate) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerSetPlaybackRate', [rate]);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerSetPlaybackRate', [rate]);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerModPlaybackRate', $.proxy(function(e, rate) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerModPlaybackRate', Romo.proxy(function(e, rate) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerModPlaybackRate', [rate]);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerModPlaybackRate', [rate]);
     }
   }, this));
 
   // fullscreen triggers
 
-  this.elem.on('romoModalVideo:romoVideo:triggerEnterFullscreen', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerEnterFullscreen', Romo.proxy(function(e) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerEnterFullscreen', []);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerEnterFullscreen', []);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerExitFullscreen', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerExitFullscreen', Romo.proxy(function(e) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerExitFullscreen', []);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerExitFullscreen', []);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerToggleFullscreen', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerToggleFullscreen', Romo.proxy(function(e) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerToggleFullscreen', []);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerToggleFullscreen', []);
     }
   }, this));
 
   // load triggers
 
-  this.elem.on('romoModalVideo:romoVideo:triggerLoad', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerLoad', Romo.proxy(function(e) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerLoad', []);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerLoad', []);
     }
   }, this));
-  this.elem.on('romoModalVideo:romoVideo:triggerModSource', $.proxy(function(e, source) {
+  Romo.on(this.elem, 'romoModalVideo:romoVideo:triggerModSource', Romo.proxy(function(e, source) {
     if (this.romoVideo != undefined) {
-      this.romoVideo.elem.trigger('romoVideo:triggerModSource', [source]);
+      Romo.trigger(this.romoVideo.elem, 'romoVideo:triggerModSource', [source]);
     }
   }, this));
 }
 
-Romo.onInitUI(function(e) {
-  Romo.initUIElems(e, '[data-romo-modalVideo-auto="true"]').romoModalVideo();
+Romo.onInitUI(function(elem) {
+  Romo.initUIElems(elem, '[data-romo-modalVideo-auto="true"]').forEach(function(elem) { new RomoModalVideo(elem); });
 });


### PR DESCRIPTION
This is part of porting Romo to not depend on jQuery anymore.  We
are moving Romo to a vanilla js implementation and this covers the
modal video component.  This mostly consists of event handling
updates for the proxy events and updating to init the modal/video
components.  This also switches to Romo's new auto init API.

@jcredding ready for review.