### PR TITLE
Update video, dropdown video and modal video to use `RomoComponent`

### DIFF
--- a/assets/js/romo-av/dropdown_video.js
+++ b/assets/js/romo-av/dropdown_video.js
@@ -1,15 +1,11 @@
-var RomoDropdownVideo = function(elem) {
+var RomoDropdownVideo = RomoComponent(function(elem) {
   this.elem = elem;
 
   this.doInit();
   this._bindElem();
 
   this.elem.trigger('romoDropdownVideo:ready', [this]);
-}
-
-RomoDropdownVideo.prototype.doInit = function() {
-  // override as needed
-}
+});
 
 // private
 
@@ -299,6 +295,6 @@ RomoDropdownVideo.prototype._bindDropdownVideoTriggerEvents = function() {
   }, this));
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-dropdownVideo-auto="true"]').forEach(function(elem) { new RomoDropdownVideo(elem); });
-});
+// init
+
+Romo.addElemsInitSelector('[data-romo-dropdownVideo-auto="true"]', RomoDropdownVideo);

--- a/assets/js/romo-av/modal_video.js
+++ b/assets/js/romo-av/modal_video.js
@@ -1,15 +1,11 @@
-var RomoModalVideo = function(elem) {
+var RomoModalVideo = RomoComponent(function(elem) {
   this.elem = elem;
 
   this.doInit();
   this._bindElem();
 
   this.elem.trigger('romoModalVideo:ready', [this]);
-}
-
-RomoModalVideo.prototype.doInit = function() {
-  // override as needed
-}
+});
 
 // private
 
@@ -308,6 +304,6 @@ RomoModalVideo.prototype._bindModalVideoTriggerEvents = function() {
   }, this));
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-modalVideo-auto="true"]').forEach(function(elem) { new RomoModalVideo(elem); });
-});
+// init
+
+Romo.addElemsInitSelector('[data-romo-modalVideo-auto="true"]', RomoModalVideo);

--- a/assets/js/romo-av/video.js
+++ b/assets/js/romo-av/video.js
@@ -1,15 +1,11 @@
-var RomoVideo = function(elem) {
+var RomoVideo = RomoComponent(function(elem) {
   this.elem = elem;
 
   this.doInit();
   this._bindElem()
 
   Romo.trigger(this.elem, 'romoVideo:ready', [this.videoObj, this]);
-}
-
-RomoVideo.prototype.doInit = function() {
-  // override as needed
-}
+});
 
 // Playback methods
 
@@ -520,18 +516,6 @@ RomoVideo.prototype._setVolume = function(value) {
   this.doUnmute();
 }
 
-RomoVideo.prototype._onDocumentFullscreenChange = function(e) {
-  if (this._getCurrentFullscreenElem() === this.fullscreenElem) {
-    this.fullScreen = true;
-    Romo.trigger(this.elem, 'romoVideo:enterFullscreen',  [this.videoObj, this]);
-    Romo.trigger(this.elem, 'romoVideo:fullscreenChange', [this.videoObj, this]);
-  } else if (this.fullScreen === true) {
-    this.fullScreen = false;
-    Romo.trigger(this.elem, 'romoVideo:exitFullscreen',   [this.videoObj, this]);
-    Romo.trigger(this.elem, 'romoVideo:fullscreenChange', [this.videoObj, this]);
-  }
-}
-
 RomoVideo.prototype._getCurrentFullscreenElem = function() {
   return document.fullscreenElement        ||
          document.mozFullScreenElement     ||
@@ -608,6 +592,20 @@ RomoVideo.prototype._getBrowserExitFullscreen = function(fullscreenElem) {
   }
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-video-auto="true"]').forEach(function(elem) { new RomoVideo(elem); });
-});
+// event functions
+
+RomoVideo.prototype.romoEvFn._onDocumentFullscreenChange = function(e) {
+  if (this._getCurrentFullscreenElem() === this.fullscreenElem) {
+    this.fullScreen = true;
+    Romo.trigger(this.elem, 'romoVideo:enterFullscreen',  [this.videoObj, this]);
+    Romo.trigger(this.elem, 'romoVideo:fullscreenChange', [this.videoObj, this]);
+  } else if (this.fullScreen === true) {
+    this.fullScreen = false;
+    Romo.trigger(this.elem, 'romoVideo:exitFullscreen',   [this.videoObj, this]);
+    Romo.trigger(this.elem, 'romoVideo:fullscreenChange', [this.videoObj, this]);
+  }
+}
+
+// init
+
+Romo.addElemsInitSelector('[data-romo-video-auto="true"]', RomoVideo);


### PR DESCRIPTION
This updates the video, dropdown video, and modal video components
to use the `RomoComponent` function to define their classes and
switches to the new init UI logic. This is part of updating to
work with the latest changes from Romo.

This includes updating the video component to define use the
new event function logic provided by `RomoComponent` and also
removes the empty `doInit` functions as the `RomoComponent`
helper provides these automatically.

@kellyredding - Ready for review. See https://github.com/redding/romo/pull/227 and https://github.com/redding/romo/pull/239.